### PR TITLE
docs(plugin): add cg CLI cheatsheet to cg-workflow-driver

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "casegraph-plugin",
       "source": "./casegraph-plugin",
       "description": "CaseGraph CLI integration for Claude Code. Skills for workspace reading/authoring/analysis, cg-driven workflow orchestration, GraphPatch proposals, and external integrations (importer / sink / worker / storage recovery).",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "author": {
         "name": "Ryoichi Izumita"
       },

--- a/casegraph-plugin/.claude-plugin/plugin.json
+++ b/casegraph-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "casegraph-plugin",
   "description": "CaseGraph CLI integration for Claude Code. Skills for workspace reading/authoring/analysis, cg-driven workflow orchestration, GraphPatch proposals, and external integrations.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": {
     "name": "Ryoichi Izumita"
   },

--- a/casegraph-plugin/skills/cg-workflow-driver/SKILL.md
+++ b/casegraph-plugin/skills/cg-workflow-driver/SKILL.md
@@ -71,6 +71,8 @@ Skip it for tiny one-pass edits that do not need a durable case.
 
 ## Command skeleton
 
+This is the happy-path set only. For any verb, flag, enum, or jq pattern beyond what is shown here, read [cg-cli-cheatsheet.md](references/cg-cli-cheatsheet.md) **before** running `cg <verb> --help` — it is compact and covers the whole Phase 0+ surface (node update, task wait/cancel/fail, analyze, patch, sync, worker, migrate, enums). Fall back to `--help` only when the cheatsheet lacks what you need.
+
 ```sh
 cg case new --id <case_id> --title "<title>"
 cg node add --case <case_id> --id goal_<name> --kind goal --title "<goal>"
@@ -96,6 +98,7 @@ When resuming after compaction or handoff:
 
 ## References
 
+- [cg-cli-cheatsheet.md](references/cg-cli-cheatsheet.md)
 - [task-templates.md](references/task-templates.md)
 - [checkpoint-evidence.md](references/checkpoint-evidence.md)
 - [close-and-resume-rules.md](references/close-and-resume-rules.md)

--- a/casegraph-plugin/skills/cg-workflow-driver/references/cg-cli-cheatsheet.md
+++ b/casegraph-plugin/skills/cg-workflow-driver/references/cg-cli-cheatsheet.md
@@ -42,7 +42,7 @@ cg node update --case c1 --id task_x \
   --metadata '{"assignees":["alice"],"priority":"high","due_at":"2026-05-31"}'
 ```
 
-Standard keys consumed by this skill's GitHub projection: `assignees: string[]`, `priority: "high"|"medium"|"low"|number` (see `packages/kernel/src/helpers.ts:123`), `due_at: ISO8601`.
+Standard keys consumed by this skill's GitHub projection: `assignees: string[]`, `priority: "high"|"medium"|"low"|number` (see `metadataPriorityValue` in `packages/kernel/src/helpers.ts`), `due_at: ISO8601`.
 
 ### `--labels` / `--acceptance`
 

--- a/casegraph-plugin/skills/cg-workflow-driver/references/cg-cli-cheatsheet.md
+++ b/casegraph-plugin/skills/cg-workflow-driver/references/cg-cli-cheatsheet.md
@@ -1,0 +1,154 @@
+# `cg` CLI cheatsheet
+
+A compact reference of the verbs and flags the skill uses. Read this **first** when a command you need is not in the SKILL.md skeleton — it covers more than the skeleton and avoids round-trips to `cg <verb> --help`.
+
+Authoritative sources, in order: (1) `docs/spec/05-cli.md` inside the CaseGraph repo, (2) `cg <verb> --help`, (3) this cheatsheet. If they disagree, the earlier wins and this file should be updated.
+
+## Global conventions
+
+- **Global flags** (accepted on any subcommand): `--workspace <path>`, `--format <text|json>` (default `text`), `--quiet`, `--verbose`.
+- **Workspace resolution**: `--workspace` → `$CASEGRAPH_WORKSPACE` → nearest `.casegraph/` ancestor of cwd.
+- **JSON output shape**: `{ok, command, data, revision?: {current, last_event_id}}`. Read `.data...` in jq.
+- **Exit codes**: `0` ok · `2` validation · `3` not found · `4` conflict (e.g. stale `base_revision`).
+- **Revision**: almost every read command returns `.revision.current` (an integer). Used as `base_revision` in patches.
+
+## Workspace / Case
+
+| Verb | Required | Optional | Notes |
+|---|---|---|---|
+| `cg init` | — | `--title <str>` | Creates `.casegraph/` in cwd |
+| `cg case new` | `--id <caseId>` `--title <str>` | `--description <str>` | |
+| `cg case list` | — | — | JSON: `data.cases[]` |
+| `cg case show` | `--case <caseId>` | — | Returns `CaseStateView` (nodes/edges/derived/validation) |
+| `cg case view` | `--case <caseId>` | — | ASCII dependency tree (`data.tree_lines`) + structured data |
+| `cg case close` | `--case <caseId>` | `--force` | `--force` needed if validation warnings remain |
+
+Close gates: `frontier == []`, every goal terminal, zero validation errors.
+
+## Graph editing
+
+| Verb | Required | Optional | Notes |
+|---|---|---|---|
+| `cg node add` | `--case` `--kind <k>` `--title` | `--id` `--description` `--state` `--labels` `--acceptance` `--metadata <json>` | `--state` default `todo` |
+| `cg node update` | `--case` `--id <nodeId>` | `--title` `--description` `--state` `--labels` `--acceptance` `--metadata` | Passing `--state` emits `node.state_changed` event |
+| `cg edge add` | `--case` `--type <t>` | `--from`/`--source` `--to`/`--target` `--id` | `--from` and `--source` are aliases; same for `--to` / `--target` |
+| `cg edge remove` | `--case` `--id <edgeId>` | — | |
+
+### `--metadata` JSON shape
+
+Pass a JSON string. Example:
+```sh
+cg node update --case c1 --id task_x \
+  --metadata '{"assignees":["alice"],"priority":"high","due_at":"2026-05-31"}'
+```
+
+Standard keys consumed by this skill's GitHub projection: `assignees: string[]`, `priority: "high"|"medium"|"low"|number` (see `packages/kernel/src/helpers.ts:123`), `due_at: ISO8601`.
+
+### `--labels` / `--acceptance`
+
+Comma-separated strings: `--labels "security,p1"` → `["security","p1"]`. Empty string clears to `[]`.
+
+## State transitions
+
+All task-family verbs take positional `<nodeIds...>` (space-separated) and `--case`. State transitions are event-sourced; each call appends one event.
+
+| Verb | Target state | Extra flags |
+|---|---|---|
+| `cg task start <id...>` | `doing` | — |
+| `cg task done <id...>` | `done` | — |
+| `cg task wait <id...>` | `waiting` | `--reason <str>` `--for <eventNodeId>` |
+| `cg task resume <id...>` | `todo` | — |
+| `cg task cancel <id...>` | `cancelled` | — |
+| `cg task fail <id...>` | `failed` | — |
+| `cg decision decide <id...>` | `done` | `--result <str>` |
+| `cg event record <id...>` | `done` | — (must pre-exist as `kind:event`, else exit 2/3) |
+| `cg evidence add` | creates evidence node | `--case` `--title` required; `--id` `--target <verifyTarget>` `--description` `--file` `--url` optional |
+
+Note: `cg task done` is today the generic "mark a node as `done`"; it also works on `kind:goal` (there is no dedicated `goal done` yet).
+
+## Analysis
+
+| Verb | Required | Optional |
+|---|---|---|
+| `cg frontier` | `--case` | — |
+| `cg blockers` | `--case` | — |
+| `cg validate [storage]` | (`--case` when not `storage`) | — |
+| `cg analyze impact` | `--case` `--node` | — |
+| `cg analyze critical-path` | `--case` | `--goal` |
+| `cg analyze slack` | `--case` | `--goal` |
+| `cg analyze bottlenecks` | `--case` | `--goal` |
+| `cg analyze unblock` | `--case` `--node` | — |
+| `cg analyze cycles` | `--case` | `--goal` |
+| `cg analyze components` | `--case` | `--goal` |
+| `cg analyze bridges` | `--case` | `--goal` |
+| `cg analyze cutpoints` | `--case` | `--goal` |
+| `cg analyze fragility` | `--case` | `--goal` |
+
+`--goal <goalNodeId>` narrows analysis to the subgraph that contributes to a specific goal.
+
+## Patches
+
+All three take `--file <path>` (JSON or YAML, extension-detected). No stdin support.
+
+| Verb | Effect |
+|---|---|
+| `cg patch validate --file <p>` | schema only |
+| `cg patch review --file <p>` | schema + `base_revision` check + op dry-run |
+| `cg patch apply --file <p>` | above + append `patch.applied` event |
+
+Exit 4 on stale `base_revision`. Rewrite `base_revision` from `cg case show` output before retrying.
+
+## Sync / Workers
+
+| Verb | Required | Optional |
+|---|---|---|
+| `cg sync push` | `--sink <name>` `--case` | `--apply` |
+| `cg sync pull` | `--sink <name>` `--case` `--output <path>` | — |
+| `cg worker run` | `--worker <name>` `--case` `--node` | `--approve` `--output <path>` `--timeout <seconds>` |
+| `cg import markdown` | `--case` `--file <path>` | `--output <path>` |
+
+`cg sync pull` writes a `GraphPatch` to `--output`; then apply via `cg patch apply`.
+
+## Storage / Admin
+
+| Verb | Effect |
+|---|---|
+| `cg validate storage` | workspace + case metadata + event log + cache integrity |
+| `cg cache rebuild` | rebuild SQLite cache from event log |
+| `cg events verify --case <id>` | event envelope + replay integrity |
+| `cg events export --case <id>` | raw event stream |
+| `cg migrate check [--patch-file <p>]*` | scan spec_version, report pending steps |
+| `cg migrate run [--dry-run] [--patch-file <p>]*` | apply known migrations |
+
+`--patch-file` is repeatable to scan explicit patch files.
+
+## Enum reference
+
+| NodeKind | NodeState | EdgeType |
+|---|---|---|
+| `goal` | `proposed` | `depends_on` |
+| `task` | `todo` | `waits_for` |
+| `decision` | `doing` | `alternative_to` |
+| `event` | `waiting` | `verifies` |
+| `evidence` | `done` | `contributes_to` |
+| | `cancelled` | |
+| | `failed` | |
+
+## JSON extraction cookbook
+
+Common jq patterns the skill relies on. Pipe `cg ... --format json | jq ...`.
+
+- Current revision: `.revision.current`
+- Frontier node ids: `.data.nodes[].node_id`
+- Frontier by state: `.data.nodes | group_by(.state)`
+- Blocker reasons: `.data.items[] | {node: .node.node_id, reasons: .reasons}`
+- Projection mappings (code-sink only): `.data.projection_mappings`
+- Events of a kind: `.data.events[] | select(.kind == "patch.applied")`
+
+## When to prefer `--help` over this file
+
+- You see a flag in `--help` that is not here (flag drift — please patch this file in the same PR).
+- A command exits 2 and the message references an option this file does not cover.
+- You need the exact wording of an option's help text for an error-path message.
+
+Otherwise this file should be enough to write the command correctly on the first try.


### PR DESCRIPTION
## Summary

Agents using the `cg-workflow-driver` skill currently burn context on repeated `cg <verb> --help` discovery calls for verbs and flags that are not in SKILL.md's minimal happy-path skeleton. This PR adds a compact command reference bundled with the skill.

## Changes

- **New**: `casegraph-plugin/skills/cg-workflow-driver/references/cg-cli-cheatsheet.md` (~150 lines). Covers the Phase 0+ surface with required / optional flags:
  - Workspace / case verbs (init, case new/list/show/view/close)
  - Graph editing (node add/update, edge add/remove) with `--metadata` JSON shape
  - State transitions (task start/done/wait/resume/cancel/fail, decision decide, event record, evidence add)
  - Analysis (frontier, blockers, validate, analyze impact/critical-path/slack/bottlenecks/unblock/cycles/components/bridges/cutpoints/fragility)
  - Patch / sync / worker / import / migrate
  - Storage admin (cache rebuild, events verify/export)
  - Enum tables (NodeKind / NodeState / EdgeType)
  - jq cookbook for the most common JSON extraction patterns
- **Edited**: `SKILL.md` — "Command skeleton" now instructs the agent to read the cheatsheet **before** falling back to `--help`. One more bullet under "References".
- **Bumped**: plugin `0.1.4 → 0.1.5`.

## Non-goals

- Not a replacement for `docs/spec/05-cli.md` — the spec stays authoritative for repo-internal readers.
- Not auto-generated — drift is managed manually; the cheatsheet's bottom section tells contributors to patch it when a flag added to the CLI is missing.
- No code changes under `packages/**`.

## Test plan

- [ ] Install the plugin at 0.1.5; invoke the skill on a new case request.
- [ ] Verify the agent references the cheatsheet and does not run `cg case new --help`, `cg node add --help`, `cg edge add --help` during an ordinary case setup.
- [ ] For a scenario that needs `cg node update --metadata '{...}'`, verify the agent composes the flag correctly from the cheatsheet's JSON shape example.
- [ ] Spot-check that every flag in the cheatsheet matches `packages/cli/src/app.ts` as of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 包括的なCLIチートシートを追加し、主要コマンドと出力/エラー仕様を網羅

* **ドキュメント**
  * ワークフロードライバースキルの説明を更新し、コマンド例はハッピーパスのみである旨と追加参照の案内を明確化
  * CLIコマンド、グローバルフラグ、JSONスキーマ、トランジション等の詳細リファレンスを追加

* **チョア**
  * プラグインバージョンを0.1.4から0.1.5へ更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->