### PR TITLE
docs(plugin): point marketplace add at CAPHTECH/casegraph

### DIFF
--- a/casegraph-plugin/README.md
+++ b/casegraph-plugin/README.md
@@ -20,11 +20,11 @@ The skills are split so that the highest-risk surfaces stay explicit: day-to-day
 From the Claude Code CLI:
 
 ```
-/plugin marketplace add <this-repo-path-or-URL>
+/plugin marketplace add CAPHTECH/casegraph
 /plugin install casegraph-plugin@casegraph-marketplace
 ```
 
-Marketplace manifest: `../.claude-plugin/marketplace.json`.
+`CAPHTECH/casegraph` is the GitHub `owner/repo` shorthand; a full HTTPS URL also works. Marketplace manifest: `../.claude-plugin/marketplace.json`.
 
 ## Relationship to CaseGraph core
 


### PR DESCRIPTION
## Summary

`casegraph-plugin/README.md` had a placeholder `<this-repo-path-or-URL>` in the install snippet, so users could not copy-paste the instruction. Replaces it with the GitHub `owner/repo` shorthand `CAPHTECH/casegraph` (accepted by `/plugin marketplace add`) and adds a one-line note that a full HTTPS URL also works.

## Test plan

- [ ] Copy the snippet from the rendered README into Claude Code and confirm the marketplace resolves and the plugin installs without further edits.
- [ ] Confirm the HTTPS form `https://github.com/CAPHTECH/casegraph` also works as the note claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * インストール手順が更新されました。プラグインマーケットプレイスの追加手順がより具体的かつわかりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->