### PR TITLE
docs: make user-facing guides work for npm-installed cg

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,20 @@ Current implementation includes:
 
 Prerequisites:
 
-- Node.js 24+
-- `pnpm` 10+
+- Node.js 22+
 
 ```bash
-pnpm install
-pnpm build
+npm install -g @caphtech/casegraph-cli
 export WORKSPACE="$(mktemp -d /tmp/casegraph-demo.XXXXXX)"
 
-pnpm run cg --workspace "$WORKSPACE" init --title "CaseGraph Demo"
-pnpm run cg --workspace "$WORKSPACE" case new --id release-demo --title "Release demo"
-pnpm run cg --workspace "$WORKSPACE" node add --case release-demo --id goal_release_demo --kind goal --title "Release demo ready"
-pnpm run cg --workspace "$WORKSPACE" node add --case release-demo --id task_write_notes --kind task --title "Write release notes" --state todo
-pnpm run cg --workspace "$WORKSPACE" node add --case release-demo --id task_publish --kind task --title "Publish build" --state todo
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_publish_depends_notes --type depends_on --from task_publish --to task_write_notes
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-demo
-pnpm run cg --workspace "$WORKSPACE" blockers --case release-demo
+cg --workspace "$WORKSPACE" init --title "CaseGraph Demo"
+cg --workspace "$WORKSPACE" case new --id release-demo --title "Release demo"
+cg --workspace "$WORKSPACE" node add --case release-demo --id goal_release_demo --kind goal --title "Release demo ready"
+cg --workspace "$WORKSPACE" node add --case release-demo --id task_write_notes --kind task --title "Write release notes" --state todo
+cg --workspace "$WORKSPACE" node add --case release-demo --id task_publish --kind task --title "Publish build" --state todo
+cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_publish_depends_notes --type depends_on --from task_publish --to task_write_notes
+cg --workspace "$WORKSPACE" frontier --case release-demo
+cg --workspace "$WORKSPACE" blockers --case release-demo
 ```
 
 For the full walkthrough:
@@ -93,6 +91,8 @@ Release and verification guides:
 - [Manual acceptance (JA)](docs/guides/manual-acceptance.ja.md)
 
 ## Development
+
+This section is for contributors working from a clone of this repository. External users should follow the [Quickstart](#quickstart) and [Install](#install) sections above.
 
 Common commands:
 

--- a/docs/guides/manual-acceptance.en.md
+++ b/docs/guides/manual-acceptance.en.md
@@ -8,47 +8,48 @@ Estimated time: 10 to 15 minutes.
 
 ## Prerequisites
 
+- Node.js 22+ (required by `node:sqlite`)
+- `@caphtech/casegraph-cli` installed globally: `npm install -g @caphtech/casegraph-cli`
+
 ```bash
-pnpm install
-pnpm build
 export WORKSPACE="$(mktemp -d /tmp/casegraph-acceptance.XXXXXX)"
 ```
 
-Run the commands below from the repository root while targeting the empty temporary directory in `WORKSPACE`.
+Run the commands below while targeting the empty temporary directory in `WORKSPACE`. Repository contributors can substitute `pnpm run cg` for `cg` throughout.
 
 ## 1. Initialize a workspace
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" init --title "Acceptance Workspace"
+cg --workspace "$WORKSPACE" init --title "Acceptance Workspace"
 ```
 
 ## 2. Create the release example
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" case new --id release-1.8.0 --title "Release 1.8.0" --description "May release"
+cg --workspace "$WORKSPACE" case new --id release-1.8.0 --title "Release 1.8.0" --description "May release"
 
-pnpm run cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id goal_release_ready --kind goal --title "Release 1.8.0 ready"
-pnpm run cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_run_regression --kind task --title "Run regression test" --state todo --metadata '{"estimate_minutes":45}'
-pnpm run cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_update_notes --kind task --title "Update release notes" --state todo --metadata '{"estimate_minutes":15}'
-pnpm run cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_submit_store --kind task --title "Submit to App Store" --state todo --metadata '{"estimate_minutes":20}'
-pnpm run cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_monitor_post_release --kind task --title "Monitor post-release" --state todo --metadata '{"estimate_minutes":30}'
-pnpm run cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id event_release_live --kind event --title "Release live" --state todo
+cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id goal_release_ready --kind goal --title "Release 1.8.0 ready"
+cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_run_regression --kind task --title "Run regression test" --state todo --metadata '{"estimate_minutes":45}'
+cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_update_notes --kind task --title "Update release notes" --state todo --metadata '{"estimate_minutes":15}'
+cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_submit_store --kind task --title "Submit to App Store" --state todo --metadata '{"estimate_minutes":20}'
+cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_monitor_post_release --kind task --title "Monitor post-release" --state todo --metadata '{"estimate_minutes":30}'
+cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id event_release_live --kind event --title "Release live" --state todo
 
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e1 --type depends_on --from task_submit_store --to task_run_regression
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e2 --type depends_on --from task_submit_store --to task_update_notes
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e3 --type waits_for --from task_monitor_post_release --to event_release_live
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e4 --type contributes_to --from task_run_regression --to goal_release_ready
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e5 --type contributes_to --from task_update_notes --to goal_release_ready
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e6 --type contributes_to --from task_submit_store --to goal_release_ready
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e7 --type contributes_to --from task_monitor_post_release --to goal_release_ready
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e1 --type depends_on --from task_submit_store --to task_run_regression
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e2 --type depends_on --from task_submit_store --to task_update_notes
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e3 --type waits_for --from task_monitor_post_release --to event_release_live
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e4 --type contributes_to --from task_run_regression --to goal_release_ready
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e5 --type contributes_to --from task_update_notes --to goal_release_ready
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e6 --type contributes_to --from task_submit_store --to goal_release_ready
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e7 --type contributes_to --from task_monitor_post_release --to goal_release_ready
 ```
 
 ## 3. Check the initial state
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-1.8.0
-pnpm run cg --workspace "$WORKSPACE" blockers --case release-1.8.0
-pnpm run cg --workspace "$WORKSPACE" case view --case release-1.8.0
+cg --workspace "$WORKSPACE" frontier --case release-1.8.0
+cg --workspace "$WORKSPACE" blockers --case release-1.8.0
+cg --workspace "$WORKSPACE" case view --case release-1.8.0
 ```
 
 Expected result:
@@ -60,7 +61,7 @@ Expected result:
 ## 4. Push the markdown projection
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" sync push --sink markdown --case release-1.8.0 --apply
+cg --workspace "$WORKSPACE" sync push --sink markdown --case release-1.8.0 --apply
 ```
 
 This creates:
@@ -81,9 +82,9 @@ Edit the projection file and check both of these items:
 ## 6. Pull, review, and apply the sync patch
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" sync pull --sink markdown --case release-1.8.0 --output "$WORKSPACE/release-sync.patch.json"
-pnpm run cg --workspace "$WORKSPACE" patch review --file "$WORKSPACE/release-sync.patch.json"
-pnpm run cg --workspace "$WORKSPACE" patch apply --file "$WORKSPACE/release-sync.patch.json"
+cg --workspace "$WORKSPACE" sync pull --sink markdown --case release-1.8.0 --output "$WORKSPACE/release-sync.patch.json"
+cg --workspace "$WORKSPACE" patch review --file "$WORKSPACE/release-sync.patch.json"
+cg --workspace "$WORKSPACE" patch apply --file "$WORKSPACE/release-sync.patch.json"
 ```
 
 Expected result:
@@ -95,7 +96,7 @@ Expected result:
 ## 7. Confirm the next frontier item
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-1.8.0
+cg --workspace "$WORKSPACE" frontier --case release-1.8.0
 ```
 
 Expected result:
@@ -105,9 +106,9 @@ Expected result:
 ## 8. Finish the remaining release gate
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" task done --case release-1.8.0 task_submit_store
-pnpm run cg --workspace "$WORKSPACE" event record --case release-1.8.0 event_release_live
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-1.8.0
+cg --workspace "$WORKSPACE" task done --case release-1.8.0 task_submit_store
+cg --workspace "$WORKSPACE" event record --case release-1.8.0 event_release_live
+cg --workspace "$WORKSPACE" frontier --case release-1.8.0
 ```
 
 Expected result:
@@ -117,8 +118,8 @@ Expected result:
 ## 9. Run one analysis surface
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" analyze critical-path --case release-1.8.0 --goal goal_release_ready
-pnpm run cg --workspace "$WORKSPACE" analyze slack --case release-1.8.0 --goal goal_release_ready
+cg --workspace "$WORKSPACE" analyze critical-path --case release-1.8.0 --goal goal_release_ready
+cg --workspace "$WORKSPACE" analyze slack --case release-1.8.0 --goal goal_release_ready
 ```
 
 Expected result:
@@ -129,9 +130,9 @@ Expected result:
 ## 10. Verify storage integrity
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" validate storage
-pnpm run cg --workspace "$WORKSPACE" events verify --case release-1.8.0
-pnpm run cg --workspace "$WORKSPACE" cache rebuild
+cg --workspace "$WORKSPACE" validate storage
+cg --workspace "$WORKSPACE" events verify --case release-1.8.0
+cg --workspace "$WORKSPACE" cache rebuild
 ```
 
 Expected result:

--- a/docs/guides/manual-acceptance.ja.md
+++ b/docs/guides/manual-acceptance.ja.md
@@ -8,47 +8,48 @@ English: [manual-acceptance.en.md](manual-acceptance.en.md)
 
 ## 前提
 
+- Node.js 22+ (`node:sqlite` が必要)
+- `@caphtech/casegraph-cli` をグローバルインストール: `npm install -g @caphtech/casegraph-cli`
+
 ```bash
-pnpm install
-pnpm build
 export WORKSPACE="$(mktemp -d /tmp/casegraph-acceptance.XXXXXX)"
 ```
 
-以下のコマンドは repository root から実行し、空の一時ディレクトリを `WORKSPACE` で指定してください。
+以下のコマンドは空の一時ディレクトリを `WORKSPACE` で指定して実行してください。repository contributor は `cg` の代わりに `pnpm run cg` を使用できます。
 
 ## 1. workspace を初期化する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" init --title "Acceptance Workspace"
+cg --workspace "$WORKSPACE" init --title "Acceptance Workspace"
 ```
 
 ## 2. release example を作る
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" case new --id release-1.8.0 --title "Release 1.8.0" --description "May release"
+cg --workspace "$WORKSPACE" case new --id release-1.8.0 --title "Release 1.8.0" --description "May release"
 
-pnpm run cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id goal_release_ready --kind goal --title "Release 1.8.0 ready"
-pnpm run cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_run_regression --kind task --title "Run regression test" --state todo --metadata '{"estimate_minutes":45}'
-pnpm run cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_update_notes --kind task --title "Update release notes" --state todo --metadata '{"estimate_minutes":15}'
-pnpm run cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_submit_store --kind task --title "Submit to App Store" --state todo --metadata '{"estimate_minutes":20}'
-pnpm run cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_monitor_post_release --kind task --title "Monitor post-release" --state todo --metadata '{"estimate_minutes":30}'
-pnpm run cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id event_release_live --kind event --title "Release live" --state todo
+cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id goal_release_ready --kind goal --title "Release 1.8.0 ready"
+cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_run_regression --kind task --title "Run regression test" --state todo --metadata '{"estimate_minutes":45}'
+cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_update_notes --kind task --title "Update release notes" --state todo --metadata '{"estimate_minutes":15}'
+cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_submit_store --kind task --title "Submit to App Store" --state todo --metadata '{"estimate_minutes":20}'
+cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id task_monitor_post_release --kind task --title "Monitor post-release" --state todo --metadata '{"estimate_minutes":30}'
+cg --workspace "$WORKSPACE" node add --case release-1.8.0 --id event_release_live --kind event --title "Release live" --state todo
 
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e1 --type depends_on --from task_submit_store --to task_run_regression
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e2 --type depends_on --from task_submit_store --to task_update_notes
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e3 --type waits_for --from task_monitor_post_release --to event_release_live
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e4 --type contributes_to --from task_run_regression --to goal_release_ready
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e5 --type contributes_to --from task_update_notes --to goal_release_ready
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e6 --type contributes_to --from task_submit_store --to goal_release_ready
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e7 --type contributes_to --from task_monitor_post_release --to goal_release_ready
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e1 --type depends_on --from task_submit_store --to task_run_regression
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e2 --type depends_on --from task_submit_store --to task_update_notes
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e3 --type waits_for --from task_monitor_post_release --to event_release_live
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e4 --type contributes_to --from task_run_regression --to goal_release_ready
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e5 --type contributes_to --from task_update_notes --to goal_release_ready
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e6 --type contributes_to --from task_submit_store --to goal_release_ready
+cg --workspace "$WORKSPACE" edge add --case release-1.8.0 --id e7 --type contributes_to --from task_monitor_post_release --to goal_release_ready
 ```
 
 ## 3. 初期状態を確認する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-1.8.0
-pnpm run cg --workspace "$WORKSPACE" blockers --case release-1.8.0
-pnpm run cg --workspace "$WORKSPACE" case view --case release-1.8.0
+cg --workspace "$WORKSPACE" frontier --case release-1.8.0
+cg --workspace "$WORKSPACE" blockers --case release-1.8.0
+cg --workspace "$WORKSPACE" case view --case release-1.8.0
 ```
 
 期待結果:
@@ -60,7 +61,7 @@ pnpm run cg --workspace "$WORKSPACE" case view --case release-1.8.0
 ## 4. markdown projection を push する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" sync push --sink markdown --case release-1.8.0 --apply
+cg --workspace "$WORKSPACE" sync push --sink markdown --case release-1.8.0 --apply
 ```
 
 次のファイルが作られます。
@@ -81,9 +82,9 @@ projection file を編集して、次の 2 行をチェック済みにします�
 ## 6. sync patch を pull / review / apply する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" sync pull --sink markdown --case release-1.8.0 --output "$WORKSPACE/release-sync.patch.json"
-pnpm run cg --workspace "$WORKSPACE" patch review --file "$WORKSPACE/release-sync.patch.json"
-pnpm run cg --workspace "$WORKSPACE" patch apply --file "$WORKSPACE/release-sync.patch.json"
+cg --workspace "$WORKSPACE" sync pull --sink markdown --case release-1.8.0 --output "$WORKSPACE/release-sync.patch.json"
+cg --workspace "$WORKSPACE" patch review --file "$WORKSPACE/release-sync.patch.json"
+cg --workspace "$WORKSPACE" patch apply --file "$WORKSPACE/release-sync.patch.json"
 ```
 
 期待結果:
@@ -95,7 +96,7 @@ pnpm run cg --workspace "$WORKSPACE" patch apply --file "$WORKSPACE/release-sync
 ## 7. 次の frontier を確認する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-1.8.0
+cg --workspace "$WORKSPACE" frontier --case release-1.8.0
 ```
 
 期待結果:
@@ -105,9 +106,9 @@ pnpm run cg --workspace "$WORKSPACE" frontier --case release-1.8.0
 ## 8. 残りの release gate を完了する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" task done --case release-1.8.0 task_submit_store
-pnpm run cg --workspace "$WORKSPACE" event record --case release-1.8.0 event_release_live
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-1.8.0
+cg --workspace "$WORKSPACE" task done --case release-1.8.0 task_submit_store
+cg --workspace "$WORKSPACE" event record --case release-1.8.0 event_release_live
+cg --workspace "$WORKSPACE" frontier --case release-1.8.0
 ```
 
 期待結果:
@@ -117,8 +118,8 @@ pnpm run cg --workspace "$WORKSPACE" frontier --case release-1.8.0
 ## 9. analysis surface を 1 つ以上実行する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" analyze critical-path --case release-1.8.0 --goal goal_release_ready
-pnpm run cg --workspace "$WORKSPACE" analyze slack --case release-1.8.0 --goal goal_release_ready
+cg --workspace "$WORKSPACE" analyze critical-path --case release-1.8.0 --goal goal_release_ready
+cg --workspace "$WORKSPACE" analyze slack --case release-1.8.0 --goal goal_release_ready
 ```
 
 期待結果:
@@ -129,9 +130,9 @@ pnpm run cg --workspace "$WORKSPACE" analyze slack --case release-1.8.0 --goal g
 ## 10. storage の整合性を確認する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" validate storage
-pnpm run cg --workspace "$WORKSPACE" events verify --case release-1.8.0
-pnpm run cg --workspace "$WORKSPACE" cache rebuild
+cg --workspace "$WORKSPACE" validate storage
+cg --workspace "$WORKSPACE" events verify --case release-1.8.0
+cg --workspace "$WORKSPACE" cache rebuild
 ```
 
 期待結果:

--- a/docs/guides/quickstart.en.md
+++ b/docs/guides/quickstart.en.md
@@ -6,24 +6,23 @@ This guide gets a fresh workspace running, creates a small case, pushes a markdo
 
 ## Prerequisites
 
-- Node.js 24+ recommended
-- `pnpm` 10+
+- Node.js 22+ (required by `node:sqlite`)
+- `@caphtech/casegraph-cli` installed globally: `npm install -g @caphtech/casegraph-cli`
 - A writable workspace directory
+- (Repository contributors running against source may substitute `pnpm run cg` for `cg` after `pnpm install && pnpm build`.)
 
-## 1. Install and build
+## 1. Prepare a workspace directory
 
 ```bash
-pnpm install
-pnpm build
 export WORKSPACE="$(mktemp -d /tmp/casegraph-demo.XXXXXX)"
 ```
 
-Run the commands below from the repository root while targeting the empty workspace in `WORKSPACE`. The CLI entrypoint used in this guide is `pnpm run cg --workspace "$WORKSPACE"`.
+The commands below target the empty workspace in `WORKSPACE`. The CLI entrypoint used in this guide is `cg --workspace "$WORKSPACE"`.
 
 ## 2. Initialize a workspace
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" init --title "CaseGraph Demo"
+cg --workspace "$WORKSPACE" init --title "CaseGraph Demo"
 ```
 
 This creates `.casegraph/` under `"$WORKSPACE"`.
@@ -31,22 +30,22 @@ This creates `.casegraph/` under `"$WORKSPACE"`.
 ## 3. Create a small release case
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" case new --id release-demo --title "Release demo" --description "Quickstart case"
+cg --workspace "$WORKSPACE" case new --id release-demo --title "Release demo" --description "Quickstart case"
 
-pnpm run cg --workspace "$WORKSPACE" node add --case release-demo --id goal_release_demo --kind goal --title "Release demo ready"
-pnpm run cg --workspace "$WORKSPACE" node add --case release-demo --id task_write_notes --kind task --title "Write release notes" --state todo
-pnpm run cg --workspace "$WORKSPACE" node add --case release-demo --id task_publish --kind task --title "Publish build" --state todo
+cg --workspace "$WORKSPACE" node add --case release-demo --id goal_release_demo --kind goal --title "Release demo ready"
+cg --workspace "$WORKSPACE" node add --case release-demo --id task_write_notes --kind task --title "Write release notes" --state todo
+cg --workspace "$WORKSPACE" node add --case release-demo --id task_publish --kind task --title "Publish build" --state todo
 
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_publish_depends_notes --type depends_on --from task_publish --to task_write_notes
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_notes_goal --type contributes_to --from task_write_notes --to goal_release_demo
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_publish_goal --type contributes_to --from task_publish --to goal_release_demo
+cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_publish_depends_notes --type depends_on --from task_publish --to task_write_notes
+cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_notes_goal --type contributes_to --from task_write_notes --to goal_release_demo
+cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_publish_goal --type contributes_to --from task_publish --to goal_release_demo
 ```
 
 ## 4. Inspect the initial state
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-demo
-pnpm run cg --workspace "$WORKSPACE" blockers --case release-demo
+cg --workspace "$WORKSPACE" frontier --case release-demo
+cg --workspace "$WORKSPACE" blockers --case release-demo
 ```
 
 Expected result:
@@ -57,7 +56,7 @@ Expected result:
 ## 5. Push the markdown projection
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" sync push --sink markdown --case release-demo --apply
+cg --workspace "$WORKSPACE" sync push --sink markdown --case release-demo --apply
 ```
 
 This writes:
@@ -85,16 +84,16 @@ to:
 ## 7. Pull the change back as a patch
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" sync pull --sink markdown --case release-demo --output "$WORKSPACE/release-demo-sync.patch.json"
-pnpm run cg --workspace "$WORKSPACE" patch review --file "$WORKSPACE/release-demo-sync.patch.json"
-pnpm run cg --workspace "$WORKSPACE" patch apply --file "$WORKSPACE/release-demo-sync.patch.json"
+cg --workspace "$WORKSPACE" sync pull --sink markdown --case release-demo --output "$WORKSPACE/release-demo-sync.patch.json"
+cg --workspace "$WORKSPACE" patch review --file "$WORKSPACE/release-demo-sync.patch.json"
+cg --workspace "$WORKSPACE" patch apply --file "$WORKSPACE/release-demo-sync.patch.json"
 ```
 
 ## 8. Confirm the next actionable task
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-demo
-pnpm run cg --workspace "$WORKSPACE" case view --case release-demo
+cg --workspace "$WORKSPACE" frontier --case release-demo
+cg --workspace "$WORKSPACE" case view --case release-demo
 ```
 
 Expected result:
@@ -105,24 +104,24 @@ Expected result:
 ## 9. Optional analysis commands
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" analyze critical-path --case release-demo --goal goal_release_demo
-pnpm run cg --workspace "$WORKSPACE" analyze slack --case release-demo --goal goal_release_demo
-pnpm run cg --workspace "$WORKSPACE" analyze bottlenecks --case release-demo --goal goal_release_demo
+cg --workspace "$WORKSPACE" analyze critical-path --case release-demo --goal goal_release_demo
+cg --workspace "$WORKSPACE" analyze slack --case release-demo --goal goal_release_demo
+cg --workspace "$WORKSPACE" analyze bottlenecks --case release-demo --goal goal_release_demo
 ```
 
 ## 10. Record the case as complete
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" task done --case release-demo task_publish
-pnpm run cg --workspace "$WORKSPACE" evidence add --case release-demo \
+cg --workspace "$WORKSPACE" task done --case release-demo task_publish
+cg --workspace "$WORKSPACE" evidence add --case release-demo \
   --id evidence_publish_receipt \
   --title "Published build receipt" \
   --target task_publish \
   --url "https://example.invalid/releases/demo"
-pnpm run cg --workspace "$WORKSPACE" task done --case release-demo goal_release_demo
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-demo
-pnpm run cg --workspace "$WORKSPACE" validate --case release-demo
-pnpm run cg --workspace "$WORKSPACE" case show --case release-demo
+cg --workspace "$WORKSPACE" task done --case release-demo goal_release_demo
+cg --workspace "$WORKSPACE" frontier --case release-demo
+cg --workspace "$WORKSPACE" validate --case release-demo
+cg --workspace "$WORKSPACE" case show --case release-demo
 ```
 
 Expected result:
@@ -137,8 +136,8 @@ Completion is represented through the combination of goal state, evidence, front
 ## 11. Optionally close the case
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" case close --case release-demo
-pnpm run cg --workspace "$WORKSPACE" case show --case release-demo
+cg --workspace "$WORKSPACE" case close --case release-demo
+cg --workspace "$WORKSPACE" case show --case release-demo
 ```
 
 Expected result:

--- a/docs/guides/quickstart.ja.md
+++ b/docs/guides/quickstart.ja.md
@@ -6,24 +6,23 @@ English: [quickstart.en.md](quickstart.en.md)
 
 ## 前提
 
-- Node.js 24 以上を推奨
-- `pnpm` 10 以上
+- Node.js 22 以上（`node:sqlite` が必要）
+- `@caphtech/casegraph-cli` をグローバルにインストール: `npm install -g @caphtech/casegraph-cli`
 - 書き込み可能な作業ディレクトリ
+- （リポジトリのコントリビューターがソースから実行する場合は、`pnpm install && pnpm build` のうえで `cg` の代わりに `pnpm run cg` を使ってもかまいません。）
 
-## 1. 依存を入れて build する
+## 1. workspace ディレクトリを準備する
 
 ```bash
-pnpm install
-pnpm build
 export WORKSPACE="$(mktemp -d /tmp/casegraph-demo.XXXXXX)"
 ```
 
-以下のコマンドは repository root から実行し、空の workspace を `WORKSPACE` で指定します。このガイドで使う CLI 起動方法は `pnpm run cg --workspace "$WORKSPACE"` です。
+以下のコマンドは、空の workspace を `WORKSPACE` で指定して実行します。このガイドで使う CLI 起動方法は `cg --workspace "$WORKSPACE"` です。
 
 ## 2. workspace を初期化する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" init --title "CaseGraph Demo"
+cg --workspace "$WORKSPACE" init --title "CaseGraph Demo"
 ```
 
 `"$WORKSPACE"` 配下に `.casegraph/` が作られます。
@@ -31,22 +30,22 @@ pnpm run cg --workspace "$WORKSPACE" init --title "CaseGraph Demo"
 ## 3. 小さな release case を作る
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" case new --id release-demo --title "Release demo" --description "Quickstart case"
+cg --workspace "$WORKSPACE" case new --id release-demo --title "Release demo" --description "Quickstart case"
 
-pnpm run cg --workspace "$WORKSPACE" node add --case release-demo --id goal_release_demo --kind goal --title "Release demo ready"
-pnpm run cg --workspace "$WORKSPACE" node add --case release-demo --id task_write_notes --kind task --title "Write release notes" --state todo
-pnpm run cg --workspace "$WORKSPACE" node add --case release-demo --id task_publish --kind task --title "Publish build" --state todo
+cg --workspace "$WORKSPACE" node add --case release-demo --id goal_release_demo --kind goal --title "Release demo ready"
+cg --workspace "$WORKSPACE" node add --case release-demo --id task_write_notes --kind task --title "Write release notes" --state todo
+cg --workspace "$WORKSPACE" node add --case release-demo --id task_publish --kind task --title "Publish build" --state todo
 
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_publish_depends_notes --type depends_on --from task_publish --to task_write_notes
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_notes_goal --type contributes_to --from task_write_notes --to goal_release_demo
-pnpm run cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_publish_goal --type contributes_to --from task_publish --to goal_release_demo
+cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_publish_depends_notes --type depends_on --from task_publish --to task_write_notes
+cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_notes_goal --type contributes_to --from task_write_notes --to goal_release_demo
+cg --workspace "$WORKSPACE" edge add --case release-demo --id edge_publish_goal --type contributes_to --from task_publish --to goal_release_demo
 ```
 
 ## 4. 初期状態を見る
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-demo
-pnpm run cg --workspace "$WORKSPACE" blockers --case release-demo
+cg --workspace "$WORKSPACE" frontier --case release-demo
+cg --workspace "$WORKSPACE" blockers --case release-demo
 ```
 
 期待結果:
@@ -57,7 +56,7 @@ pnpm run cg --workspace "$WORKSPACE" blockers --case release-demo
 ## 5. markdown projection を push する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" sync push --sink markdown --case release-demo --apply
+cg --workspace "$WORKSPACE" sync push --sink markdown --case release-demo --apply
 ```
 
 次のファイルが出力されます。
@@ -85,16 +84,16 @@ built-in の markdown sync は v0.1 の required reference integration なので
 ## 7. 変更を patch として pull する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" sync pull --sink markdown --case release-demo --output "$WORKSPACE/release-demo-sync.patch.json"
-pnpm run cg --workspace "$WORKSPACE" patch review --file "$WORKSPACE/release-demo-sync.patch.json"
-pnpm run cg --workspace "$WORKSPACE" patch apply --file "$WORKSPACE/release-demo-sync.patch.json"
+cg --workspace "$WORKSPACE" sync pull --sink markdown --case release-demo --output "$WORKSPACE/release-demo-sync.patch.json"
+cg --workspace "$WORKSPACE" patch review --file "$WORKSPACE/release-demo-sync.patch.json"
+cg --workspace "$WORKSPACE" patch apply --file "$WORKSPACE/release-demo-sync.patch.json"
 ```
 
 ## 8. 次の着手可能 task を確認する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-demo
-pnpm run cg --workspace "$WORKSPACE" case view --case release-demo
+cg --workspace "$WORKSPACE" frontier --case release-demo
+cg --workspace "$WORKSPACE" case view --case release-demo
 ```
 
 期待結果:
@@ -105,24 +104,24 @@ pnpm run cg --workspace "$WORKSPACE" case view --case release-demo
 ## 9. 任意で分析コマンドを試す
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" analyze critical-path --case release-demo --goal goal_release_demo
-pnpm run cg --workspace "$WORKSPACE" analyze slack --case release-demo --goal goal_release_demo
-pnpm run cg --workspace "$WORKSPACE" analyze bottlenecks --case release-demo --goal goal_release_demo
+cg --workspace "$WORKSPACE" analyze critical-path --case release-demo --goal goal_release_demo
+cg --workspace "$WORKSPACE" analyze slack --case release-demo --goal goal_release_demo
+cg --workspace "$WORKSPACE" analyze bottlenecks --case release-demo --goal goal_release_demo
 ```
 
 ## 10. 完了として記録する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" task done --case release-demo task_publish
-pnpm run cg --workspace "$WORKSPACE" evidence add --case release-demo \
+cg --workspace "$WORKSPACE" task done --case release-demo task_publish
+cg --workspace "$WORKSPACE" evidence add --case release-demo \
   --id evidence_publish_receipt \
   --title "Published build receipt" \
   --target task_publish \
   --url "https://example.invalid/releases/demo"
-pnpm run cg --workspace "$WORKSPACE" task done --case release-demo goal_release_demo
-pnpm run cg --workspace "$WORKSPACE" frontier --case release-demo
-pnpm run cg --workspace "$WORKSPACE" validate --case release-demo
-pnpm run cg --workspace "$WORKSPACE" case show --case release-demo
+cg --workspace "$WORKSPACE" task done --case release-demo goal_release_demo
+cg --workspace "$WORKSPACE" frontier --case release-demo
+cg --workspace "$WORKSPACE" validate --case release-demo
+cg --workspace "$WORKSPACE" case show --case release-demo
 ```
 
 期待結果:
@@ -137,8 +136,8 @@ goal / evidence / frontier / validate の組み合わせで completion を表し
 ## 11. 必要なら case を close する
 
 ```bash
-pnpm run cg --workspace "$WORKSPACE" case close --case release-demo
-pnpm run cg --workspace "$WORKSPACE" case show --case release-demo
+cg --workspace "$WORKSPACE" case close --case release-demo
+cg --workspace "$WORKSPACE" case show --case release-demo
 ```
 
 期待結果:


### PR DESCRIPTION
## Summary

The top-level README demo, `docs/guides/quickstart.{en,ja}.md`, and `docs/guides/manual-acceptance.{en,ja}.md` told external users to run `pnpm install && pnpm build` and then `pnpm run cg --workspace ...` for every command. This only works from a repo clone — users who installed via `npm install -g @caphtech/casegraph-cli` (which is exactly what the Install section of the README itself advertises) had no working path through these guides.

This PR rewrites those five user-facing docs to:

1. **Prerequisites** — drop `pnpm 10+`, list Node 22+ (the real minimum for `node:sqlite`) and the npm global install. Previous preamble was also overstating the Node version as 24+.
2. **Every command line** — `pnpm run cg --workspace "$WORKSPACE" <verb>` → `cg --workspace "$WORKSPACE" <verb>`.
3. **Contributor fallback** — one-line note preserved in each guide: contributors working from source can substitute `pnpm run cg` after `pnpm install && pnpm build`. The README Development section is also explicitly scoped to contributors.

### Deliberately NOT changed (correct for their audience)

- `docs/guides/release-checklist.{en,ja}.md` — maintainer-facing.
- `docs/guides/npm-release.{en,ja}.md` — uses `pnpm --filter ... publish`, which is the right tool for the job.
- `docs/releases/v0.1.0-rc1.{en,ja}.md` — historical release notes.
- `AGENTS.md` — contributor guide.
- `casegraph-plugin/skills/*/SKILL.md` — Command bootstrap sections already resolve between `cg` and `pnpm cg` based on context.
- README's Development section — keeps `pnpm run cg` for contributors.

### Scale

| File | Changed lines | `pnpm run cg` before → after |
|---|---|---|
| `README.md` | 24 | 9 → 1 (Development section) |
| `docs/guides/quickstart.en.md` | 65 | 28 → 1 (contributor note) |
| `docs/guides/quickstart.ja.md` | 65 | 28 → 1 (contributor note) |
| `docs/guides/manual-acceptance.en.md` | 73 | 31 → 1 (contributor note) |
| `docs/guides/manual-acceptance.ja.md` | 73 | 31 → 1 (contributor note) |

EN and JA files had matching occurrence counts before and after — translation pairs stayed in sync.

## Test plan

- [ ] Copy the updated top-level README demo into a fresh terminal on a machine with only `npm install -g @caphtech/casegraph-cli` run; confirm all commands succeed end-to-end without needing `pnpm`.
- [ ] Follow the updated `docs/guides/quickstart.en.md` end-to-end from a fresh workspace; confirm every command works with globally-installed `cg`.
- [ ] Spot-check `docs/guides/quickstart.ja.md` matches the EN version section-by-section.
- [ ] Spot-check `docs/guides/manual-acceptance.{en,ja}.md` fixture IDs (`release-1.8.0`, `move-case`) are unchanged.
- [ ] Verify contributor path still works: `pnpm install && pnpm build && pnpm run cg --workspace "$WS" --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * Node.js の必須バージョンを 24+ から 22+ に更新しました
  * セットアップ手順を簡略化し、`@caphtech/casegraph-cli` のグローバル npm インストールを推奨するようにしました
  * すべてのコマンド実行方法を `pnpm run cg` から直接 `cg` コマンドの呼び出しに変更しました
  * クイックスタートおよび各種ガイドドキュメントをすべて更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->