### PR TITLE
feat(plugin): add cg-review-driver skill for AI-work audit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "casegraph-plugin",
       "source": "./casegraph-plugin",
       "description": "CaseGraph CLI integration for Claude Code. Skills for workspace reading/authoring/analysis, cg-driven workflow orchestration, GraphPatch proposals, and external integrations (importer / sink / worker / storage recovery).",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "author": {
         "name": "Ryoichi Izumita"
       },

--- a/casegraph-plugin/.claude-plugin/plugin.json
+++ b/casegraph-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "casegraph-plugin",
   "description": "CaseGraph CLI integration for Claude Code. Skills for workspace reading/authoring/analysis, cg-driven workflow orchestration, GraphPatch proposals, and external integrations.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": {
     "name": "Ryoichi Izumita"
   },

--- a/casegraph-plugin/skills/cg-review-driver/SKILL.md
+++ b/casegraph-plugin/skills/cg-review-driver/SKILL.md
@@ -46,7 +46,7 @@ Out of scope in v0.1: batch review across multiple cases, diff reviews between t
 Run in order. Each phase reads from `--format json` and pipes through jq — never emit mutating commands. Detail in [review-phases.md](references/review-phases.md).
 
 1. **Orientation** — `cg case show --case <id> --format json` → read `revision.current`, `case.state`. Then `cg case view --case <id> --format json` → full `nodes[]` / `edges[]` / `derived[]` / `validation[]` arrays that later phases query. If `--since-revision` is set, scope all later event-log queries to events newer than that revision.
-2. **State Health** — `cg validate --case <id> --format json` (errors must be 0), `cg events verify --case <id> --format json` (**HARD STOP** if integrity fails — the graph itself is not trustworthy), then `cg frontier --case <id>` and `cg blockers --case <id>`.
+2. **State Health** — `cg validate --case <id> --format json` (errors must be 0), `cg events verify --case <id> --format json` (**HARD STOP** if integrity fails — the graph itself is not trustworthy), then `cg frontier --case <id> --format json` and `cg blockers --case <id> --format json`.
 3. **Evidence Integrity** — find done-without-verifies, empty-evidence, and just-in-time evidence per [evidence-integrity-rules.md](references/evidence-integrity-rules.md).
 4. **Decision Traceability** — every `kind:decision` in `state:done` should have `metadata.result` or a non-empty description. Flag naked decisions.
 5. **Event Trail Audit** — `cg events export --case <id> --format json` and apply [event-trail-jq.md](references/event-trail-jq.md) patterns to classify patches by `generator.kind`, detect orphan workers, list cancel/fail transitions.

--- a/casegraph-plugin/skills/cg-review-driver/SKILL.md
+++ b/casegraph-plugin/skills/cg-review-driver/SKILL.md
@@ -45,7 +45,7 @@ Out of scope in v0.1: batch review across multiple cases, diff reviews between t
 
 Run in order. Each phase reads from `--format json` and pipes through jq — never emit mutating commands. Detail in [review-phases.md](references/review-phases.md).
 
-1. **Orientation** — `cg case show --case <id> --format json` → snapshot `revision.current`, `caseRecord.state`, count nodes by kind × state. If `--since-revision` is set, scope all later queries to events newer than that revision.
+1. **Orientation** — `cg case show --case <id> --format json` → read `revision.current`, `case.state`. Then `cg case view --case <id> --format json` → full `nodes[]` / `edges[]` / `derived[]` / `validation[]` arrays that later phases query. If `--since-revision` is set, scope all later event-log queries to events newer than that revision.
 2. **State Health** — `cg validate --case <id> --format json` (errors must be 0), `cg events verify --case <id> --format json` (**HARD STOP** if integrity fails — the graph itself is not trustworthy), then `cg frontier --case <id>` and `cg blockers --case <id>`.
 3. **Evidence Integrity** — find done-without-verifies, empty-evidence, and just-in-time evidence per [evidence-integrity-rules.md](references/evidence-integrity-rules.md).
 4. **Decision Traceability** — every `kind:decision` in `state:done` should have `metadata.result` or a non-empty description. Flag naked decisions.

--- a/casegraph-plugin/skills/cg-review-driver/SKILL.md
+++ b/casegraph-plugin/skills/cg-review-driver/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: cg-review-driver
+description: Use when the user wants to review AI-performed work on a CaseGraph case. Trigger on phrases like "case <id> をレビューして", "AI がやった作業を確認して", "review the case", "audit this case", "証跡をチェックして", or whenever a structured read-only inspection of task completion, evidence integrity, decision traceability, and event-log trustworthiness is needed.
+---
+
+# Review AI-performed work through CaseGraph
+
+## Overview
+
+Run a structured, read-only audit of a case after an AI has performed work on it. Produce a markdown review report classifying findings as must-fix (🔴), should-review (🟡), or note (🟢), and list external artifacts that still require human cross-check. Never mutate the graph — the only writes allowed are the report text and, if explicitly requested, one `evidence.attached` event at the end to record the review itself.
+
+Use this skill after **cg-workflow-driver** or another AI-driven loop has produced done tasks, new decisions, evidence nodes, and patch-applied events. For live workflow orchestration use **cg-workflow-driver**. For AI-authored graph changes use **casegraph-patch**. For raw workspace reading use **casegraph**.
+
+## Command bootstrap
+
+Resolve a working launcher before using the commands below:
+
+1. If `cg --help` works, use `cg`.
+2. If CaseGraph is installed locally in the current project, use `pnpm exec cg --help` or `npx cg --help`.
+3. If you are inside the CaseGraph repository, run `pnpm install` and `pnpm build`, then use `pnpm cg --help`.
+4. If none of those work, install `@caphtech/casegraph-cli` and use either global `cg` or project-local `pnpm exec cg`.
+
+In the rest of this skill, `cg ...` means "use the launcher that succeeded here."
+
+## When to use
+
+Use this skill when:
+
+- an AI-driven loop has just marked tasks done and the case is about to be closed
+- work is being handed off between sessions and the next agent needs to know what is already trustworthy
+- a periodic audit is due on a long-running case
+- someone asks "did the AI actually do this" and the answer must be graph-evidence based, not vibes
+
+Skip it for a case that has only human edits, or for a case with fewer than a handful of nodes.
+
+## Capability tiers
+
+- **Core (always on)** — Phases A–E machine checks, Phase F item enumeration, markdown report output.
+- **Opt-in: scoped review** — pass `--since-revision <n>` or `--since-timestamp <ISO8601>` to the skill to ignore history before that point. Useful on long-running cases to avoid re-reviewing everything.
+- **Opt-in: record the review** — when the human says "record this review" (or equivalent), attach the report as a single `evidence` node on the case root via `cg evidence add`. Default off.
+
+Out of scope in v0.1: batch review across multiple cases, diff reviews between two revisions, automated Phase F execution.
+
+## Operating loop (6 phases)
+
+Run in order. Each phase reads from `--format json` and pipes through jq — never emit mutating commands. Detail in [review-phases.md](references/review-phases.md).
+
+1. **Orientation** — `cg case show --case <id> --format json` → snapshot `revision.current`, `caseRecord.state`, count nodes by kind × state. If `--since-revision` is set, scope all later queries to events newer than that revision.
+2. **State Health** — `cg validate --case <id> --format json` (errors must be 0), `cg events verify --case <id> --format json` (**HARD STOP** if integrity fails — the graph itself is not trustworthy), then `cg frontier --case <id>` and `cg blockers --case <id>`.
+3. **Evidence Integrity** — find done-without-verifies, empty-evidence, and just-in-time evidence per [evidence-integrity-rules.md](references/evidence-integrity-rules.md).
+4. **Decision Traceability** — every `kind:decision` in `state:done` should have `metadata.result` or a non-empty description. Flag naked decisions.
+5. **Event Trail Audit** — `cg events export --case <id> --format json` and apply [event-trail-jq.md](references/event-trail-jq.md) patterns to classify patches by `generator.kind`, detect orphan workers, list cancel/fail transitions.
+6. **Reality Cross-Check** — enumerate files, tests, PRs, URLs claimed by evidence nodes. Do not auto-verify; list them for the human under "Manual cross-check required" in the report.
+
+## Verdict gates
+
+| Verdict | Condition |
+|---|---|
+| 🔴 Red | Phase B failed (event log verify or validation errors > 0), or any `kind in {task, decision}` with `state: done` has no `verifies` edge, or any `worker.dispatched` event lacks a matching `worker.finished`. Short-circuit: Red results cause later phases to be reported but not trusted. |
+| 🟡 Yellow | Any just-in-time evidence, naked decision, AI-authored (`generator.kind in {agent, worker}`) `patch.applied` without an accompanying `evidence.attached` event in the same revision range, or `state: open` with a non-empty frontier when the user's prompt implied the case was done. |
+| 🟢 Green | No Red or Yellow findings. Only 🟢 notes and "Manual cross-check required" items remain. A Green verdict is **not** an automatic approval — it means the graph side passes; the human still owns Phase F. |
+
+## Report output
+
+Emit a single markdown document. Do not split into multiple files. Shape is fixed by [report-template.md](references/report-template.md). Keep it pasteable into a PR description or a chat thread.
+
+When the user asks to record the review, attach it via:
+
+```sh
+cg evidence add --case <id> \
+  --id evidence_review_<ISO8601_compact> \
+  --title "Review report at revision <n>" \
+  --target <case_root_or_most_relevant_goal_id> \
+  --description "<full markdown report or summary + link to where the full text is stored>"
+```
+
+This is the only mutating command the skill ever emits, and only on explicit request.
+
+## What this skill does NOT do
+
+- Does not author patches. If the review suggests a fix, hand off to **casegraph-patch**.
+- Does not close cases. `cg case close` stays with **cg-workflow-driver**.
+- Does not automatically verify Phase F items (files, tests, PRs). The skill surfaces them; the human runs `git log`, reruns tests, opens PRs.
+- Does not consume the full event log when `--since-revision` is set — scoping is strict so a long case stays reviewable.
+- Does not run `cg patch apply`, `cg task ...`, `cg node ...`, `cg edge ...`, or any other mutating verb. Its entire output is read queries plus (optionally) one `cg evidence add` at the end.
+
+## References
+
+- [review-phases.md](references/review-phases.md)
+- [evidence-integrity-rules.md](references/evidence-integrity-rules.md)
+- [event-trail-jq.md](references/event-trail-jq.md)
+- [report-template.md](references/report-template.md)
+
+## Related
+
+- live workflow orchestration: **cg-workflow-driver**
+- AI-authored graph changes via `GraphPatch`: **casegraph-patch**
+- direct workspace reading: **casegraph**
+- importers, workers, sync, and storage recovery: **casegraph-integrate**

--- a/casegraph-plugin/skills/cg-review-driver/references/event-trail-jq.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/event-trail-jq.md
@@ -1,16 +1,32 @@
 # Event trail jq cookbook
 
-Phase E patterns for `cg events export --case <id> --format json`. All snippets assume the export is saved at `/tmp/cg-review-events.json` and the case snapshot at `/tmp/cg-review-snapshot.json` (set by Phase A).
+Phase E patterns for `cg events export --case <id> --format json`. All snippets assume the export is saved at `/tmp/cg-review-events.json` and the case view snapshot at `/tmp/cg-review-view.json` (set by Phase A via `cg case view --case <id> --format json`).
 
-Events have shape:
+The full CLI result is shaped `{ ok, command, data: { case_id, events: [...] } }`, so unwrap with `.data.events` before any pipeline.
+
+Events have shape (from `packages/kernel/src/types.ts::EventEnvelope`):
 
 ```json
-{ "kind": "...",
+{ "type": "...",
   "event_id": "ulid",
-  "created_at": "2026-04-20T10:15:30Z",
+  "spec_version": "0.1-draft",
+  "case_id": "...",
+  "timestamp": "2026-04-20T10:15:30Z",
   "actor": { "kind": "human|agent|worker|importer|sync", "name": "..." },
-  "payload": { "..." : "..." } }
+  "source": "cli|patch|worker|sync",
+  "payload": { "...": "..." },
+  "command_id": "...",
+  "correlation_id": "...",
+  "causation_id": "...",
+  "revision_hint": 42 }
 ```
+
+Relevant payload shapes encountered below:
+
+- `patch.applied`: `{ patch: GraphPatch }` — read `payload.patch.generator.kind`, `payload.patch.operations`, `payload.patch.summary`, `payload.patch.patch_id`.
+- `evidence.attached`: `{ node: NodeRecord, verifies_edge?: EdgeRecord, attachment?: AttachmentRecord }` — read `payload.node.node_id` for the evidence id and `payload.verifies_edge.target_id` for the verified target.
+- `node.state_changed`: `{ node_id, state, metadata? }` — note `state`, not `to_state`.
+- `worker.dispatched` / `worker.finished`: `{ worker_name, node_id, command_id, ... }` — match the pair by `command_id`.
 
 Common event kinds encountered:
 
@@ -19,7 +35,7 @@ Common event kinds encountered:
 - `evidence.attached`
 - `worker.dispatched` / `worker.finished`
 - `projection.pushed` / `projection.pulled`
-- `case.opened` / `case.closed`
+- `case.created` / `case.updated`
 
 ---
 
@@ -27,32 +43,37 @@ Common event kinds encountered:
 
 Use these as a prefix inside any later `jq` pipeline. The variable `since` is supplied by the skill when `--since-revision` is set; otherwise 0.
 
+`revision_hint` is optional, so the filter must guard against `null`.
+
 ```sh
 # --since-revision
-jq --argjson since 42 '.data | map(select(.revision > $since))' /tmp/cg-review-events.json
+jq --argjson since 42 '.data.events | map(select((.revision_hint // 0) > $since))' /tmp/cg-review-events.json
 
 # --since-timestamp
-jq --arg since "2026-04-20T00:00:00Z" '.data | map(select(.created_at >= $since))' /tmp/cg-review-events.json
+jq --arg since "2026-04-20T00:00:00Z" '.data.events | map(select(.timestamp >= $since))' /tmp/cg-review-events.json
 ```
 
 Save the clipped result once:
 
 ```sh
-jq --argjson since 42 '.data | map(select(.revision > $since))' /tmp/cg-review-events.json > /tmp/cg-review-events.clip.json
+jq --argjson since 42 '.data.events | map(select((.revision_hint // 0) > $since))' /tmp/cg-review-events.json > /tmp/cg-review-events.clip.json
 ```
 
-Everything below operates on the clipped array. Substitute `.data` if you skipped clipping.
+Everything below operates on the clipped array. Substitute `.data.events` if you skipped clipping.
 
 ---
 
 ## 1. Patches by generator.kind
 
+`generator` is optional on `GraphPatch`; fall back to `"unknown"` so grouping still yields a bucket for patches that omit it.
+
 ```sh
 jq '
-  map(select(.kind == "patch.applied"))
-  | group_by(.payload.generator.kind)
-  | map({ actor: .[0].payload.generator.kind, count: length,
-          summaries: map(.payload.summary) | .[0:3] })
+  map(select(.type == "patch.applied"))
+  | group_by(.payload.patch.generator.kind // "unknown")
+  | map({ actor: (.[0].payload.patch.generator.kind // "unknown"),
+          count: length,
+          summaries: map(.payload.patch.summary) | .[0:3] })
 ' /tmp/cg-review-events.clip.json
 ```
 
@@ -62,18 +83,22 @@ Use the count breakdown for the "Actor distribution" 🟢 note. Sample up to 3 s
 
 ## 2. AI patches without an accompanying evidence attachment
 
-An AI-authored patch (`generator.kind in {agent, worker}`) that claims task progress should be accompanied by an `evidence.attached` event on at least one of the patch's affected nodes, within the same clip window.
+An AI-authored patch (`generator.kind in {agent, worker}`) that claims task progress should be accompanied by an `evidence.attached` event whose `verifies_edge.target_id` matches at least one of the patch's affected nodes, within the same clip window.
 
 ```sh
 jq '
-  (map(select(.kind == "evidence.attached")) | map(.payload.target_id // empty)) as $verified_targets
-  | map(select(.kind == "patch.applied" and
-               (.payload.generator.kind == "agent" or .payload.generator.kind == "worker")))
+  (map(select(.type == "evidence.attached"))
+   | map(.payload.verifies_edge.target_id // empty)) as $verified_targets
+  | map(select(.type == "patch.applied" and
+               ((.payload.patch.generator.kind // "") == "agent"
+                or (.payload.patch.generator.kind // "") == "worker")))
   | map({
-      patch_id: .payload.patch_id,
-      summary: .payload.summary,
-      affected: (.payload.operations // [] | map(.node_id // .node.node_id // empty) | unique),
-      at: .created_at
+      patch_id: .payload.patch.patch_id,
+      summary: .payload.patch.summary,
+      affected: (.payload.patch.operations // []
+                 | map(.node_id // .node.node_id // empty)
+                 | unique),
+      at: .timestamp
     })
   | map(. + { evidenced: (any(.affected[]; . as $n | $verified_targets | index($n))) })
   | map(select(.evidenced | not))
@@ -82,15 +107,16 @@ jq '
 
 Each entry returned is a 🟡 `ai-patch-without-evidence` finding. The `affected` list and `summary` let the reviewer decide whether evidence was reasonable to expect.
 
-False positives: patches that only change metadata / labels / descriptions, not state. Filter those out by restricting to operations whose `op` is `change_state` or `add_node` with a substantive `kind`:
+False positives: patches that only change metadata / labels / descriptions, not state. Filter those out by restricting to operations whose `op` is `change_node_state` setting `state == "done"`, or `add_node` with a substantive `kind`:
 
 ```sh
 # stricter: only patches that touched task/decision state
 jq '
-  map(select(.kind == "patch.applied"))
-  | map(select(.payload.generator.kind == "agent" or .payload.generator.kind == "worker"))
-  | map(select((.payload.operations // [])
-      | any(.op == "change_state" and (.to_state == "done" or .state == "done"))))
+  map(select(.type == "patch.applied"))
+  | map(select((.payload.patch.generator.kind // "") == "agent"
+               or (.payload.patch.generator.kind // "") == "worker"))
+  | map(select((.payload.patch.operations // [])
+      | any(.op == "change_node_state" and .state == "done")))
 ' /tmp/cg-review-events.clip.json
 ```
 
@@ -100,24 +126,25 @@ Combine with the "no evidence" filter above to reduce noise.
 
 ## 3. Orphan workers
 
-A `worker.dispatched` without a matching `worker.finished` indicates a worker started and never reported back. Always 🔴.
+A `worker.dispatched` without a matching `worker.finished` indicates a worker started and never reported back. Always 🔴. Match the pair by `command_id` (issued once per dispatch; echoed on `finished`).
 
 ```sh
 jq '
-  (map(select(.kind == "worker.finished"))
-   | map({ w: (.payload.worker_name // .payload.worker),
-           n: .payload.node_id,
-           d: .payload.dispatched_event_id })) as $done
-  | map(select(.kind == "worker.dispatched"))
+  (map(select(.type == "worker.finished"))
+   | map({ cid: .payload.command_id,
+           w: .payload.worker_name,
+           n: .payload.node_id })) as $done
+  | map(select(.type == "worker.dispatched"))
   | map({
       dispatched_id: .event_id,
-      worker: (.payload.worker_name // .payload.worker),
+      command_id: .payload.command_id,
+      worker: .payload.worker_name,
       node: .payload.node_id,
-      at: .created_at
+      at: .timestamp
     })
   | map(. + {
       matched: (. as $d | $done
-                 | map(select((.d == $d.dispatched_id)
+                 | map(select(.cid == $d.command_id
                          or (.w == $d.worker and .n == $d.node)))
                  | length > 0)
     })
@@ -125,50 +152,52 @@ jq '
 ' /tmp/cg-review-events.clip.json
 ```
 
-`worker.finished` payload schemas vary by worker. The query matches on either the explicit `dispatched_event_id` back-reference or the `(worker_name, node_id)` pair as fallback.
+The query matches primarily by `command_id`, falling back to the `(worker_name, node_id)` pair for robustness across worker implementations.
 
 ---
 
 ## 4. Cancel / fail history
 
-Surface every transition to `cancelled` or `failed`, plus whether the node later became `done` (reversal pattern).
+Surface every transition to `cancelled` or `failed`, plus whether the node later became `done` (reversal pattern). Note that `node.state_changed` uses `payload.state` (not `to_state`).
 
 ```sh
 jq '
-  map(select(.kind == "node.state_changed"))
+  map(select(.type == "node.state_changed"))
   | group_by(.payload.node_id)
   | map({
       node: .[0].payload.node_id,
-      transitions: map({ at: .created_at, to: .payload.to_state,
-                         reason: .payload.reason }),
-      final: (last.payload.to_state)
+      transitions: map({ at: .timestamp,
+                         to: .payload.state,
+                         reason: (.payload.metadata.last_wait_reason // null) }),
+      final: (last.payload.state)
     })
   | map(select(.transitions | map(.to) | any(. == "cancelled" or . == "failed")))
 ' /tmp/cg-review-events.clip.json
 ```
 
-Post-process: emit 🟢 `actor-distribution` / `cancel-history` notes for entries whose `final` is `cancelled` (legitimate dead-end) or `failed` (legitimate failure). Emit 🟡 `silent-reversal` for entries whose transitions include `failed` then later `done`; Rule 4 in [evidence-integrity-rules.md](evidence-integrity-rules.md) owns the intervening-evidence check.
+Post-process: emit 🟢 `cancel-history` notes for entries whose `final` is `cancelled` (legitimate dead-end) or `failed` (legitimate failure). Emit 🟡 `silent-reversal` for entries whose transitions include `failed` then later `done`; Rule 4 in [evidence-integrity-rules.md](evidence-integrity-rules.md) owns the intervening-evidence check.
 
 ---
 
 ## 5. Worker timing outliers (🟢 note)
 
-Workers whose `finished` event arrives > 10 minutes after their `dispatched`. Not a failure, but worth surfacing: slow workers often indicate flaky tooling or timeouts that silently retried.
+Workers whose `finished` event arrives > 10 minutes after their `dispatched`. Not a failure, but worth surfacing: slow workers often indicate flaky tooling or timeouts that silently retried. Pair by `command_id`.
 
 ```sh
 jq '
-  (map(select(.kind == "worker.dispatched"))
-   | map({ id: .event_id, at: .created_at,
-           worker: (.payload.worker_name // .payload.worker),
+  (map(select(.type == "worker.dispatched"))
+   | map({ cid: .payload.command_id,
+           at: .timestamp,
+           worker: .payload.worker_name,
            node: .payload.node_id })) as $dispatched
-  | map(select(.kind == "worker.finished"))
+  | map(select(.type == "worker.finished"))
   | map({
-      worker: (.payload.worker_name // .payload.worker),
+      worker: .payload.worker_name,
       node: .payload.node_id,
-      finished_at: .created_at,
+      command_id: .payload.command_id,
+      finished_at: .timestamp,
       dispatched_at: (. as $f | $dispatched
-                        | map(select(.worker == $f.payload.worker_name
-                                     and .node == $f.payload.node_id))
+                        | map(select(.cid == $f.payload.command_id))
                         | first | .at)
     })
   | map(select(.dispatched_at))
@@ -182,23 +211,25 @@ jq '
 
 ## 6. Revision range covered
 
+`revision_hint` is optional on each event envelope; fall back to `null` when absent.
+
 ```sh
 jq '{
-  first_event: (.[0] | { revision, at: .created_at }),
-  last_event:  (.[-1] | { revision, at: .created_at }),
+  first_event: (.[0] | { revision_hint: (.revision_hint // null), at: .timestamp }),
+  last_event:  (.[-1] | { revision_hint: (.revision_hint // null), at: .timestamp }),
   total: length
 }' /tmp/cg-review-events.clip.json
 ```
 
-Populates the Report "Health" block.
+Populates the Report "Health" block. The authoritative current revision lives on `cg case show`'s `data.revision.current` — use that for the report's "Revision" header, and this query only to describe the clipped window.
 
 ---
 
-## 7. Event-kind histogram
+## 7. Event-type histogram
 
 ```sh
 jq '
-  group_by(.kind) | map({ kind: .[0].kind, n: length })
+  group_by(.type) | map({ type: .[0].type, n: length })
   | sort_by(-.n)
 ' /tmp/cg-review-events.clip.json
 ```
@@ -209,5 +240,5 @@ Useful as a quick sanity check — an unusually large number of `node.state_chan
 
 ## Notes on portability
 
-- The jq patterns assume the CaseGraph event envelope shape as of spec 0.1-draft. If the envelope evolves, update the field paths in a single place and re-run against a recent export to confirm.
+- The jq patterns track the CaseGraph event envelope shape as of spec 0.1-draft (`packages/kernel/src/types.ts`). If the envelope evolves, update the field paths in a single place and re-run against a recent export to confirm.
 - When the skill runs `jq` inside a Bash command, quote single-quotes inside expressions by breaking into multiple `-f` files or using `jq -n --argjson ...` to pass data from flags. Inline multi-line scripts are fine for the report skill because the output is human-read, not programmatically consumed.

--- a/casegraph-plugin/skills/cg-review-driver/references/event-trail-jq.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/event-trail-jq.md
@@ -1,0 +1,213 @@
+# Event trail jq cookbook
+
+Phase E patterns for `cg events export --case <id> --format json`. All snippets assume the export is saved at `/tmp/cg-review-events.json` and the case snapshot at `/tmp/cg-review-snapshot.json` (set by Phase A).
+
+Events have shape:
+
+```json
+{ "kind": "...",
+  "event_id": "ulid",
+  "created_at": "2026-04-20T10:15:30Z",
+  "actor": { "kind": "human|agent|worker|importer|sync", "name": "..." },
+  "payload": { "..." : "..." } }
+```
+
+Common event kinds encountered:
+
+- `patch.applied`
+- `node.state_changed`
+- `evidence.attached`
+- `worker.dispatched` / `worker.finished`
+- `projection.pushed` / `projection.pulled`
+- `case.opened` / `case.closed`
+
+---
+
+## Since-revision / since-timestamp filter
+
+Use these as a prefix inside any later `jq` pipeline. The variable `since` is supplied by the skill when `--since-revision` is set; otherwise 0.
+
+```sh
+# --since-revision
+jq --argjson since 42 '.data | map(select(.revision > $since))' /tmp/cg-review-events.json
+
+# --since-timestamp
+jq --arg since "2026-04-20T00:00:00Z" '.data | map(select(.created_at >= $since))' /tmp/cg-review-events.json
+```
+
+Save the clipped result once:
+
+```sh
+jq --argjson since 42 '.data | map(select(.revision > $since))' /tmp/cg-review-events.json > /tmp/cg-review-events.clip.json
+```
+
+Everything below operates on the clipped array. Substitute `.data` if you skipped clipping.
+
+---
+
+## 1. Patches by generator.kind
+
+```sh
+jq '
+  map(select(.kind == "patch.applied"))
+  | group_by(.payload.generator.kind)
+  | map({ actor: .[0].payload.generator.kind, count: length,
+          summaries: map(.payload.summary) | .[0:3] })
+' /tmp/cg-review-events.clip.json
+```
+
+Use the count breakdown for the "Actor distribution" 🟢 note. Sample up to 3 summaries per actor to paste into the report for context.
+
+---
+
+## 2. AI patches without an accompanying evidence attachment
+
+An AI-authored patch (`generator.kind in {agent, worker}`) that claims task progress should be accompanied by an `evidence.attached` event on at least one of the patch's affected nodes, within the same clip window.
+
+```sh
+jq '
+  (map(select(.kind == "evidence.attached")) | map(.payload.target_id // empty)) as $verified_targets
+  | map(select(.kind == "patch.applied" and
+               (.payload.generator.kind == "agent" or .payload.generator.kind == "worker")))
+  | map({
+      patch_id: .payload.patch_id,
+      summary: .payload.summary,
+      affected: (.payload.operations // [] | map(.node_id // .node.node_id // empty) | unique),
+      at: .created_at
+    })
+  | map(. + { evidenced: (any(.affected[]; . as $n | $verified_targets | index($n))) })
+  | map(select(.evidenced | not))
+' /tmp/cg-review-events.clip.json
+```
+
+Each entry returned is a 🟡 `ai-patch-without-evidence` finding. The `affected` list and `summary` let the reviewer decide whether evidence was reasonable to expect.
+
+False positives: patches that only change metadata / labels / descriptions, not state. Filter those out by restricting to operations whose `op` is `change_state` or `add_node` with a substantive `kind`:
+
+```sh
+# stricter: only patches that touched task/decision state
+jq '
+  map(select(.kind == "patch.applied"))
+  | map(select(.payload.generator.kind == "agent" or .payload.generator.kind == "worker"))
+  | map(select((.payload.operations // [])
+      | any(.op == "change_state" and (.to_state == "done" or .state == "done"))))
+' /tmp/cg-review-events.clip.json
+```
+
+Combine with the "no evidence" filter above to reduce noise.
+
+---
+
+## 3. Orphan workers
+
+A `worker.dispatched` without a matching `worker.finished` indicates a worker started and never reported back. Always 🔴.
+
+```sh
+jq '
+  (map(select(.kind == "worker.finished"))
+   | map({ w: (.payload.worker_name // .payload.worker),
+           n: .payload.node_id,
+           d: .payload.dispatched_event_id })) as $done
+  | map(select(.kind == "worker.dispatched"))
+  | map({
+      dispatched_id: .event_id,
+      worker: (.payload.worker_name // .payload.worker),
+      node: .payload.node_id,
+      at: .created_at
+    })
+  | map(. + {
+      matched: (. as $d | $done
+                 | map(select((.d == $d.dispatched_id)
+                         or (.w == $d.worker and .n == $d.node)))
+                 | length > 0)
+    })
+  | map(select(.matched | not))
+' /tmp/cg-review-events.clip.json
+```
+
+`worker.finished` payload schemas vary by worker. The query matches on either the explicit `dispatched_event_id` back-reference or the `(worker_name, node_id)` pair as fallback.
+
+---
+
+## 4. Cancel / fail history
+
+Surface every transition to `cancelled` or `failed`, plus whether the node later became `done` (reversal pattern).
+
+```sh
+jq '
+  map(select(.kind == "node.state_changed"))
+  | group_by(.payload.node_id)
+  | map({
+      node: .[0].payload.node_id,
+      transitions: map({ at: .created_at, to: .payload.to_state,
+                         reason: .payload.reason }),
+      final: (last.payload.to_state)
+    })
+  | map(select(.transitions | map(.to) | any(. == "cancelled" or . == "failed")))
+' /tmp/cg-review-events.clip.json
+```
+
+Post-process: emit 🟢 `actor-distribution` / `cancel-history` notes for entries whose `final` is `cancelled` (legitimate dead-end) or `failed` (legitimate failure). Emit 🟡 `silent-reversal` for entries whose transitions include `failed` then later `done`; Rule 4 in [evidence-integrity-rules.md](evidence-integrity-rules.md) owns the intervening-evidence check.
+
+---
+
+## 5. Worker timing outliers (🟢 note)
+
+Workers whose `finished` event arrives > 10 minutes after their `dispatched`. Not a failure, but worth surfacing: slow workers often indicate flaky tooling or timeouts that silently retried.
+
+```sh
+jq '
+  (map(select(.kind == "worker.dispatched"))
+   | map({ id: .event_id, at: .created_at,
+           worker: (.payload.worker_name // .payload.worker),
+           node: .payload.node_id })) as $dispatched
+  | map(select(.kind == "worker.finished"))
+  | map({
+      worker: (.payload.worker_name // .payload.worker),
+      node: .payload.node_id,
+      finished_at: .created_at,
+      dispatched_at: (. as $f | $dispatched
+                        | map(select(.worker == $f.payload.worker_name
+                                     and .node == $f.payload.node_id))
+                        | first | .at)
+    })
+  | map(select(.dispatched_at))
+  | map(. + { delta_s: (((.finished_at | fromdateiso8601)
+                        - (.dispatched_at | fromdateiso8601))) })
+  | map(select(.delta_s > 600))
+' /tmp/cg-review-events.clip.json
+```
+
+---
+
+## 6. Revision range covered
+
+```sh
+jq '{
+  first_event: (.[0] | { revision, at: .created_at }),
+  last_event:  (.[-1] | { revision, at: .created_at }),
+  total: length
+}' /tmp/cg-review-events.clip.json
+```
+
+Populates the Report "Health" block.
+
+---
+
+## 7. Event-kind histogram
+
+```sh
+jq '
+  group_by(.kind) | map({ kind: .[0].kind, n: length })
+  | sort_by(-.n)
+' /tmp/cg-review-events.clip.json
+```
+
+Useful as a quick sanity check — an unusually large number of `node.state_changed` without a proportionate `evidence.attached` count hints at under-documentation.
+
+---
+
+## Notes on portability
+
+- The jq patterns assume the CaseGraph event envelope shape as of spec 0.1-draft. If the envelope evolves, update the field paths in a single place and re-run against a recent export to confirm.
+- When the skill runs `jq` inside a Bash command, quote single-quotes inside expressions by breaking into multiple `-f` files or using `jq -n --argjson ...` to pass data from flags. Inline multi-line scripts are fine for the report skill because the output is human-read, not programmatically consumed.

--- a/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
@@ -15,17 +15,21 @@ Per `packages/kernel/src/types.ts`, the event envelope uses `type` / `timestamp`
 
 ## Rule 1 — `done-without-verifies` (🔴)
 
-**Statement.** For every node with `kind in {task, decision}` and `state == "done"`, there must be at least one edge with `type == "verifies"` whose `target_id` equals that node's `node_id` and whose `source_id` points to a node with `kind == "evidence"`.
+**Statement.** For every node with `kind in {task, decision}` and `state == "done"`, there must be at least one edge with `type == "verifies"` whose `target_id` equals that node's `node_id` and whose `source_id` points to a node with `kind == "evidence"` **and** `state == "done"`. An in-progress or failed evidence node does not count as verification — this matches `packages/kernel/src/validation.ts::hasEvidenceForNode`.
 
 **Detection.**
 
 ```text
-let evidence_nodes := { n.node_id | n in snapshot.nodes, n.kind == "evidence" }
+let done_evidence_nodes := {
+  n.node_id
+  | n in snapshot.nodes,
+    n.kind == "evidence" and n.state == "done"
+}
 let verified_by_evidence := {
   e.target_id
   | e in snapshot.edges,
     e.type == "verifies" and
-    e.source_id in evidence_nodes
+    e.source_id in done_evidence_nodes
 }
 for n in snapshot.nodes:
   if n.kind in {task, decision} and n.state == "done":

--- a/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
@@ -1,0 +1,160 @@
+# Evidence integrity rules
+
+Formal rules applied in Phase C of the review loop. The ordering is important: each rule has a severity, and a severity downgrade path when specific conditions are met.
+
+All rules operate on:
+- `snapshot` = `cg case show --case <id> --format json | .data`
+- `events` = `cg events export --case <id> --format json | .data`
+
+---
+
+## Rule 1 — `done-without-verifies` (🔴)
+
+**Statement.** For every node with `kind in {task, decision}` and `state == "done"`, there must be at least one edge with `type == "verifies"` whose `target_id` equals that node's `node_id` and whose `source_id` points to a node with `kind == "evidence"`.
+
+**Detection.**
+
+```
+let verified := { e.target_id | e in snapshot.edges, e.type == "verifies" }
+let evidence_sources := { e.source_id | e in snapshot.edges, e.type == "verifies" } ∩ { n.node_id | n in snapshot.nodes, n.kind == "evidence" }
+for n in snapshot.nodes:
+  if n.kind in {task, decision} and n.state == "done":
+    if n.node_id not in verified:
+      emit RED done-without-verifies { node_id: n.node_id, kind: n.kind, title: n.title }
+```
+
+**No downgrade.** Self-declared completion without evidence is the central failure mode this skill guards against. Always 🔴.
+
+**Acceptable narrow exception.** `kind == "goal"` done without verifies is currently tolerated because CaseGraph has no dedicated `goal done` verb and goals are often "done" as a consequence of child task completion. This exception applies to `goal` only; `task` and `decision` remain strict.
+
+---
+
+## Rule 2 — `empty-evidence` (🟡)
+
+**Statement.** An `evidence` node's `description` field must carry substantive content. "Substantive" is defined operationally:
+
+- length ≥ 20 characters, AND
+- does not match (case-insensitive) the regex `^(実施|完了|done|ok|yes|finished)[.。]?$`, AND
+- is not purely whitespace plus punctuation.
+
+**Detection.**
+
+```
+for n in snapshot.nodes where n.kind == "evidence":
+  desc := n.description or ""
+  if len(desc) < 20 or desc.matches(placeholder_regex):
+    emit YELLOW empty-evidence { node_id: n.node_id, description_len: len(desc) }
+```
+
+**Downgrade to 🟢 note.** When the evidence node has substantive metadata instead — at least one of `metadata.file`, `metadata.url`, `metadata.pr_url`, `metadata.commit_sha`, `metadata.test` — the empty description is acceptable. The artifact reference itself carries the signal.
+
+---
+
+## Rule 3 — `just-in-time-evidence` (🟡)
+
+**Statement.** The `evidence.attached` event for an evidence node and the `node.state_changed` → `done` event for its verified target must not be suspiciously adjacent in time.
+
+**Definition.** Let:
+- `t_evidence` = `created_at` of the `evidence.attached` event whose payload references the evidence node
+- `t_done` = `created_at` of the `node.state_changed` event with `payload.to_state == "done"` for the target node
+
+If `|t_done - t_evidence| ≤ 2 seconds`, the evidence is just-in-time. Severity:
+
+- 0 s delta (same second): strong suspicion. Emit 🟡 with `severity_hint: near-certain`.
+- 1–2 s delta: weak suspicion. Emit 🟡 with `severity_hint: plausible-batch`.
+- \> 2 s delta: no finding.
+
+**Detection.**
+
+```
+for ev in events where ev.kind == "evidence.attached":
+  evidence_id := ev.payload.node_id
+  target_id := verifies_edge_source(evidence_id)   # via snapshot.edges
+  if target_id is None: continue
+  done_ev := first(events where
+    ev2.kind == "node.state_changed" and
+    ev2.payload.node_id == target_id and
+    ev2.payload.to_state == "done")
+  if done_ev is None: continue
+  delta := abs(parse_iso(ev.created_at) - parse_iso(done_ev.created_at))
+  if delta <= 2.0:
+    emit YELLOW just-in-time-evidence {
+      evidence_id, target_id,
+      delta_seconds: delta,
+      severity_hint: (delta == 0 ? "near-certain" : "plausible-batch")
+    }
+```
+
+**Downgrade to 🟢 note.** When the evidence description contains a verifiable artifact reference whose native timestamp is materially older than the evidence event — PR URL with a known `created_at`, commit SHA resolvable via `git show`, test run log with an earlier execution timestamp — the timing finding is downgraded. The artifact existed before the evidence, so the "just-in-time" appearance is a documentation delay rather than fabrication.
+
+Downgrade requires *verifiable* reference, not a claim. `description: "see PR #42"` is not enough unless `metadata.pr_url` is populated or `#42` appears with a `github.com` URL that the report can emit as a Phase F cross-check item.
+
+---
+
+## Rule 4 — `silent-reversal` (🟡)
+
+**Statement.** A node that transitioned through `failed` and later reached `done` should have an evidence attachment dated **between** the two events. The pattern otherwise implies "I tried, it failed, then I quietly declared done without re-proving anything."
+
+**Detection.**
+
+```
+for n in snapshot.nodes where n.state == "done":
+  transitions := [ ev for ev in events where
+                    ev.kind == "node.state_changed" and
+                    ev.payload.node_id == n.node_id ]
+  if any(ev.payload.to_state == "failed" for ev in transitions):
+    last_failed := last such event
+    final_done := last event with to_state == "done"
+    intervening_evidence := any(ev for ev in events where
+      ev.kind == "evidence.attached" and
+      verifies_edge_source(ev.payload.node_id) == n.node_id and
+      last_failed.created_at < ev.created_at < final_done.created_at)
+    if not intervening_evidence:
+      emit YELLOW silent-reversal { node_id: n.node_id, failed_at, done_at }
+```
+
+**No downgrade.** The whole point of the pattern is that the fix was not documented.
+
+---
+
+## Rule 5 — `verifies-to-non-evidence` (🔴)
+
+**Statement.** A `verifies` edge whose `source_id` points to a node of kind other than `evidence` is a schema-level abuse that this skill should not silently accept.
+
+**Detection.**
+
+```
+for e in snapshot.edges where e.type == "verifies":
+  src := lookup_node(e.source_id)
+  if src is None or src.kind != "evidence":
+    emit RED verifies-to-non-evidence { edge_id: e.edge_id, source_kind: src?.kind }
+```
+
+**No downgrade.** Schema integrity; validator should have caught this, but the skill re-checks because Phase B's `cg validate` does not enforce edge-endpoint-kind rules universally across future schema changes.
+
+---
+
+## Rule 6 — `verifies-across-cases` (🔴, defensive)
+
+**Statement.** Both endpoints of a `verifies` edge must live in the current case. Trivially true in v0.1 (CaseGraph edges are single-case only), but the rule exists as a forward-looking assertion; if cross-case edges are introduced later, evidence from another case pointed at this case's task is not acceptable without a separate integrity review.
+
+**Detection.** v0.1: no-op (CaseGraph enforces this). Keep the rule entry as a placeholder.
+
+---
+
+## Finding-writing conventions
+
+When emitting a finding, always include:
+
+- `rule_id`: stable name (e.g. `done-without-verifies`)
+- `severity`: 🔴 / 🟡 / 🟢
+- `node_id` or `edge_id`: the precise target
+- a one-line `message`: what a reviewer needs to act on
+
+Do not soften the message based on AI tone. "Task `task_foo` was marked done without a `verifies` edge" is better than "Task `task_foo` appears to be missing verification, which may indicate...". The report is meant to be scanned, not read.
+
+---
+
+## Exception list (project-specific overrides)
+
+Empty in v0.1. If the project adopts conventions that legitimately break a rule (e.g. evidence routinely comes from CI logs and is attached seconds after task completion by a trusted pipeline), add an override section here listing the exact rule, the condition, and the justification. Until that happens, every flag stands.

--- a/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
@@ -3,8 +3,13 @@
 Formal rules applied in Phase C of the review loop. The ordering is important: each rule has a severity, and a severity downgrade path when specific conditions are met.
 
 All rules operate on:
-- `snapshot` = `cg case show --case <id> --format json | .data`
-- `events` = `cg events export --case <id> --format json | .data`
+- `snapshot` = `cg case view --case <id> --format json | .data` — the view command exposes the full `nodes[]` / `edges[]` arrays. `cg case show` only carries a summary.
+- `events` = `cg events export --case <id> --format json | .data.events` — the full CLI result is `{ ok, data: { case_id, events: [...] } }`.
+
+Per `packages/kernel/src/types.ts`, the event envelope uses `type` / `timestamp` / optional `revision_hint`. Payload shapes cited below:
+- `evidence.attached`: `{ node, verifies_edge?, attachment? }` — the evidence node id is `payload.node.node_id`; the verified target is `payload.verifies_edge.target_id`.
+- `node.state_changed`: `{ node_id, state, metadata? }` — note `state`, not `to_state`.
+- `patch.applied`: `{ patch }` — generator lives at `payload.patch.generator`, operations at `payload.patch.operations`.
 
 ---
 
@@ -55,8 +60,8 @@ for n in snapshot.nodes where n.kind == "evidence":
 **Statement.** The `evidence.attached` event for an evidence node and the `node.state_changed` → `done` event for its verified target must not be suspiciously adjacent in time.
 
 **Definition.** Let:
-- `t_evidence` = `created_at` of the `evidence.attached` event whose payload references the evidence node
-- `t_done` = `created_at` of the `node.state_changed` event with `payload.to_state == "done"` for the target node
+- `t_evidence` = `timestamp` of the `evidence.attached` event whose payload references the evidence node
+- `t_done` = `timestamp` of the `node.state_changed` event with `payload.state == "done"` for the target node
 
 If `|t_done - t_evidence| ≤ 2 seconds`, the evidence is just-in-time. Severity:
 
@@ -67,16 +72,16 @@ If `|t_done - t_evidence| ≤ 2 seconds`, the evidence is just-in-time. Severity
 **Detection.**
 
 ```
-for ev in events where ev.kind == "evidence.attached":
-  evidence_id := ev.payload.node_id
-  target_id := verifies_edge_source(evidence_id)   # via snapshot.edges
+for ev in events where ev.type == "evidence.attached":
+  evidence_id := ev.payload.node.node_id
+  target_id := ev.payload.verifies_edge.target_id    # directly on the event
   if target_id is None: continue
   done_ev := first(events where
-    ev2.kind == "node.state_changed" and
+    ev2.type == "node.state_changed" and
     ev2.payload.node_id == target_id and
-    ev2.payload.to_state == "done")
+    ev2.payload.state == "done")
   if done_ev is None: continue
-  delta := abs(parse_iso(ev.created_at) - parse_iso(done_ev.created_at))
+  delta := abs(parse_iso(ev.timestamp) - parse_iso(done_ev.timestamp))
   if delta <= 2.0:
     emit YELLOW just-in-time-evidence {
       evidence_id, target_id,
@@ -100,15 +105,15 @@ Downgrade requires *verifiable* reference, not a claim. `description: "see PR #4
 ```
 for n in snapshot.nodes where n.state == "done":
   transitions := [ ev for ev in events where
-                    ev.kind == "node.state_changed" and
+                    ev.type == "node.state_changed" and
                     ev.payload.node_id == n.node_id ]
-  if any(ev.payload.to_state == "failed" for ev in transitions):
+  if any(ev.payload.state == "failed" for ev in transitions):
     last_failed := last such event
-    final_done := last event with to_state == "done"
+    final_done := last event with payload.state == "done"
     intervening_evidence := any(ev for ev in events where
-      ev.kind == "evidence.attached" and
-      verifies_edge_source(ev.payload.node_id) == n.node_id and
-      last_failed.created_at < ev.created_at < final_done.created_at)
+      ev.type == "evidence.attached" and
+      ev.payload.verifies_edge.target_id == n.node_id and
+      last_failed.timestamp < ev.timestamp < final_done.timestamp)
     if not intervening_evidence:
       emit YELLOW silent-reversal { node_id: n.node_id, failed_at, done_at }
 ```

--- a/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
@@ -20,11 +20,16 @@ Per `packages/kernel/src/types.ts`, the event envelope uses `type` / `timestamp`
 **Detection.**
 
 ```text
-let verified := { e.target_id | e in snapshot.edges, e.type == "verifies" }
-let evidence_sources := { e.source_id | e in snapshot.edges, e.type == "verifies" } ∩ { n.node_id | n in snapshot.nodes, n.kind == "evidence" }
+let evidence_nodes := { n.node_id | n in snapshot.nodes, n.kind == "evidence" }
+let verified_by_evidence := {
+  e.target_id
+  | e in snapshot.edges,
+    e.type == "verifies" and
+    e.source_id in evidence_nodes
+}
 for n in snapshot.nodes:
   if n.kind in {task, decision} and n.state == "done":
-    if n.node_id not in verified:
+    if n.node_id not in verified_by_evidence:
       emit RED done-without-verifies { node_id: n.node_id, kind: n.kind, title: n.title }
 ```
 
@@ -111,7 +116,7 @@ for ev in events where ev.type == "evidence.attached":
 
 **Downgrade to 🟢 note.** When the evidence description contains a verifiable artifact reference whose native timestamp is materially older than the evidence event — PR URL with a known `created_at`, commit SHA resolvable via `git show`, test run log with an earlier execution timestamp — the timing finding is downgraded. The artifact existed before the evidence, so the "just-in-time" appearance is a documentation delay rather than fabrication.
 
-Downgrade requires *verifiable* reference, not a claim. `description: "see PR #42"` is not enough unless `metadata.pr_url` is populated or `#42` appears with a `github.com` URL that the report can emit as a Phase F cross-check item.
+Downgrade requires *verifiable* reference, not a claim. `description: "see PR #42"` is not enough unless `metadata.pr_url` is populated or `#42` appears with a GitHub URL that the report can emit as a Phase F cross-check item.
 
 ---
 

--- a/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
@@ -36,28 +36,34 @@ for n in snapshot.nodes:
 
 ## Rule 2 — `empty-evidence` (🟡)
 
-**Statement.** An `evidence` node's `description` field must carry substantive content. "Substantive" is defined operationally by the single shared placeholder regex:
+**Statement.** An `evidence` node's `description` field must carry substantive content. "Substantive" is defined operationally by two shared regexes:
 
 ```text
 placeholder_regex := /^(実施|完了|done|ok|yes|finished)[.。]?$/i
+punct_only_regex  := /^[\p{P}\p{S}]+$/u
 ```
 
 A description fails Rule 2 when any of the following holds:
 
 - length < 20 characters, OR
 - trimmed description matches `placeholder_regex`, OR
-- trimmed description is empty (purely whitespace plus punctuation).
+- trimmed description is empty, OR
+- trimmed description matches `punct_only_regex` (e.g. `......`, `——`, `??!!`).
 
-Detection uses the exact same `placeholder_regex` — do not inline a second pattern.
+Detection uses the exact same regexes — do not inline a second pattern.
 
 **Detection.**
 
 ```text
 placeholder_regex := /^(実施|完了|done|ok|yes|finished)[.。]?$/i
+punct_only_regex  := /^[\p{P}\p{S}]+$/u
 for n in snapshot.nodes where n.kind == "evidence":
   desc := n.description or ""
   trimmed := desc.strip()
-  if len(desc) < 20 or trimmed.matches(placeholder_regex) or trimmed == "":
+  if len(desc) < 20
+     or trimmed.matches(placeholder_regex)
+     or trimmed == ""
+     or trimmed.matches(punct_only_regex):
     emit YELLOW empty-evidence { node_id: n.node_id, description_len: len(desc) }
 ```
 

--- a/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
@@ -19,7 +19,7 @@ Per `packages/kernel/src/types.ts`, the event envelope uses `type` / `timestamp`
 
 **Detection.**
 
-```
+```text
 let verified := { e.target_id | e in snapshot.edges, e.type == "verifies" }
 let evidence_sources := { e.source_id | e in snapshot.edges, e.type == "verifies" } ∩ { n.node_id | n in snapshot.nodes, n.kind == "evidence" }
 for n in snapshot.nodes:
@@ -38,7 +38,7 @@ for n in snapshot.nodes:
 
 **Statement.** An `evidence` node's `description` field must carry substantive content. "Substantive" is defined operationally by the single shared placeholder regex:
 
-```
+```text
 placeholder_regex := /^(実施|完了|done|ok|yes|finished)[.。]?$/i
 ```
 
@@ -52,7 +52,7 @@ Detection uses the exact same `placeholder_regex` — do not inline a second pat
 
 **Detection.**
 
-```
+```text
 placeholder_regex := /^(実施|完了|done|ok|yes|finished)[.。]?$/i
 for n in snapshot.nodes where n.kind == "evidence":
   desc := n.description or ""
@@ -81,7 +81,7 @@ If `|t_done - t_evidence| ≤ 2 seconds`, the evidence is just-in-time. Severity
 
 **Detection.** When a target node transitions through `done` more than once (e.g. `done → failed → done`), pick the `done` event nearest to the evidence in time — prefer the first `done` at or after the evidence, otherwise the nearest done by absolute timestamp delta. Fixing on `first(done)` would misjudge late-reopened tasks.
 
-```
+```text
 for ev in events where ev.type == "evidence.attached":
   evidence_id := ev.payload.node.node_id
   target_id := ev.payload.verifies_edge.target_id    # directly on the event
@@ -115,7 +115,7 @@ Downgrade requires *verifiable* reference, not a claim. `description: "see PR #4
 
 **Detection.**
 
-```
+```text
 for n in snapshot.nodes where n.state == "done":
   transitions := [ ev for ev in events where
                     ev.type == "node.state_changed" and
@@ -123,10 +123,12 @@ for n in snapshot.nodes where n.state == "done":
   if any(ev.payload.state == "failed" for ev in transitions):
     last_failed := last such event
     final_done := last event with payload.state == "done"
+    failed_at := last_failed.timestamp
+    done_at := final_done.timestamp
     intervening_evidence := any(ev for ev in events where
       ev.type == "evidence.attached" and
       ev.payload.verifies_edge.target_id == n.node_id and
-      last_failed.timestamp < ev.timestamp < final_done.timestamp)
+      failed_at < ev.timestamp < done_at)
     if not intervening_evidence:
       emit YELLOW silent-reversal { node_id: n.node_id, failed_at, done_at }
 ```
@@ -141,7 +143,7 @@ for n in snapshot.nodes where n.state == "done":
 
 **Detection.**
 
-```
+```text
 for e in snapshot.edges where e.type == "verifies":
   src := lookup_node(e.source_id)
   if src is None or src.kind != "evidence":

--- a/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md
@@ -36,18 +36,28 @@ for n in snapshot.nodes:
 
 ## Rule 2 — `empty-evidence` (🟡)
 
-**Statement.** An `evidence` node's `description` field must carry substantive content. "Substantive" is defined operationally:
+**Statement.** An `evidence` node's `description` field must carry substantive content. "Substantive" is defined operationally by the single shared placeholder regex:
 
-- length ≥ 20 characters, AND
-- does not match (case-insensitive) the regex `^(実施|完了|done|ok|yes|finished)[.。]?$`, AND
-- is not purely whitespace plus punctuation.
+```
+placeholder_regex := /^(実施|完了|done|ok|yes|finished)[.。]?$/i
+```
+
+A description fails Rule 2 when any of the following holds:
+
+- length < 20 characters, OR
+- trimmed description matches `placeholder_regex`, OR
+- trimmed description is empty (purely whitespace plus punctuation).
+
+Detection uses the exact same `placeholder_regex` — do not inline a second pattern.
 
 **Detection.**
 
 ```
+placeholder_regex := /^(実施|完了|done|ok|yes|finished)[.。]?$/i
 for n in snapshot.nodes where n.kind == "evidence":
   desc := n.description or ""
-  if len(desc) < 20 or desc.matches(placeholder_regex):
+  trimmed := desc.strip()
+  if len(desc) < 20 or trimmed.matches(placeholder_regex) or trimmed == "":
     emit YELLOW empty-evidence { node_id: n.node_id, description_len: len(desc) }
 ```
 
@@ -69,19 +79,22 @@ If `|t_done - t_evidence| ≤ 2 seconds`, the evidence is just-in-time. Severity
 - 1–2 s delta: weak suspicion. Emit 🟡 with `severity_hint: plausible-batch`.
 - \> 2 s delta: no finding.
 
-**Detection.**
+**Detection.** When a target node transitions through `done` more than once (e.g. `done → failed → done`), pick the `done` event nearest to the evidence in time — prefer the first `done` at or after the evidence, otherwise the nearest done by absolute timestamp delta. Fixing on `first(done)` would misjudge late-reopened tasks.
 
 ```
 for ev in events where ev.type == "evidence.attached":
   evidence_id := ev.payload.node.node_id
   target_id := ev.payload.verifies_edge.target_id    # directly on the event
   if target_id is None: continue
-  done_ev := first(events where
-    ev2.type == "node.state_changed" and
-    ev2.payload.node_id == target_id and
-    ev2.payload.state == "done")
-  if done_ev is None: continue
-  delta := abs(parse_iso(ev.timestamp) - parse_iso(done_ev.timestamp))
+  done_candidates := [ ev2 for ev2 in events where
+                        ev2.type == "node.state_changed" and
+                        ev2.payload.node_id == target_id and
+                        ev2.payload.state == "done" ]
+  if done_candidates is empty: continue
+  t_ev := parse_iso(ev.timestamp)
+  done_ev := first(d in done_candidates where parse_iso(d.timestamp) >= t_ev)
+             or min_by(abs(parse_iso(d.timestamp) - t_ev) for d in done_candidates)
+  delta := abs(parse_iso(done_ev.timestamp) - t_ev)
   if delta <= 2.0:
     emit YELLOW just-in-time-evidence {
       evidence_id, target_id,

--- a/casegraph-plugin/skills/cg-review-driver/references/report-template.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/report-template.md
@@ -1,0 +1,138 @@
+# Review report template
+
+Verbatim shape the skill must emit at the end of the review loop. One markdown document, pasteable into chat, a PR description, or (if `--record-as-evidence` is on) an `evidence` node's `description`.
+
+Sections are fixed. Empty sections MUST still be rendered with the content `_(none)_` so scanning reviewers know the skill checked and found nothing, rather than that the phase was skipped.
+
+---
+
+## Template (copy, then substitute placeholders)
+
+````markdown
+# Case review: `<case_id>`
+
+- **Revision:** `<current_revision>` (reviewed window: `<window_start>`–`<current_revision>`)
+- **Case state:** `<open|closed>`
+- **Reviewed at:** `<ISO8601_now>` (UTC)
+- **Reviewer:** `cg-review-driver` v0.1
+- **Scope:** `<full | since-revision N | since-timestamp ISO>`
+
+## Verdict
+
+> `<one_of: 🔴 Red | 🟡 Yellow | 🟢 Green | ⛔ REVIEW ABORTED>`
+>
+> `<one-line rationale that includes the worst finding category>`
+
+## Health
+
+| Check | Result |
+|---|---|
+| Validation errors | `<n>` |
+| Validation warnings | `<n>` |
+| Event log integrity (`events verify`) | `<ok | FAILED>` |
+| Frontier size | `<n>` |
+| Active blockers | `<n>` |
+| Nodes by kind | `<goal=a, task=b, decision=c, event=d, evidence=e>` |
+| Events in window | `<n>` |
+| Actor distribution | `<human=X, agent=Y, worker=Z, importer=W, sync=V>` |
+
+## Findings
+
+### 🔴 Must fix (`<count>`)
+
+- **`<rule_id>`** — `<node_id_or_edge_id>`: `<one-line message>`
+- ...
+
+_(none)_ if count is 0.
+
+### 🟡 Should review (`<count>`)
+
+- **`<rule_id>`** — `<node_id>`: `<one-line message>` (severity_hint: `<optional>`)
+- ...
+
+_(none)_ if count is 0.
+
+### 🟢 Notes (`<count>`)
+
+- `<rule_id>`: `<context message>`
+- ...
+
+_(none)_ if count is 0.
+
+## Manual cross-check required (`<count>`)
+
+The skill enumerates external references. The human (or a downstream tool) runs these.
+
+- **Files** — `git log -- <path>` to confirm the evidence describes a real change:
+  - `<path1>` (from `<evidence_id>`)
+  - `<path2>` (from `<evidence_id>`)
+- **Pull requests** — `gh pr view <n>` (or open in browser):
+  - `#<n>` — `<evidence_id>` — `<url_if_present>`
+- **Issues** — `gh issue view <n>`:
+  - `#<n>` — `<evidence_id>`
+- **Commits** — `git show <sha>`:
+  - `<sha>` (from `<evidence_id>`)
+- **Tests** — rerun:
+  - `<command>` (from `<evidence_id>`)
+- **URLs** — manual inspection:
+  - `<url>` — `<evidence_id>`
+
+_(none)_ if count is 0.
+
+## Recommended next steps
+
+- If verdict is 🔴 — `<action>`: produce a `GraphPatch` via **casegraph-patch** to attach missing evidence, or revert misplaced `done` states.
+- If verdict is 🟡 — `<action>`: request the original author (AI or human) to fill in decision rationale / documentation gap before closing.
+- If verdict is 🟢 — `<action>`: complete the Manual cross-check list above. If all items pass, the case is ready for `cg case close` through **cg-workflow-driver**.
+- If verdict is ⛔ — `<action>`: stop. Investigate event-log integrity via `cg events verify` and `cg validate storage`. Do not close the case.
+
+## Snapshot references
+
+- Case snapshot: rendered from `cg case show --case <case_id> --format json` at revision `<n>`.
+- Event stream: rendered from `cg events export --case <case_id> --format json`, clipped to the review window.
+
+— end of report —
+````
+
+---
+
+## Rendering rules
+
+1. **Bullet ordering.** Findings within a severity bucket sort by `rule_id` alphabetical, then by `node_id`. Deterministic output is important when the same case is reviewed twice — diffable reports reveal real change instead of presentation drift.
+
+2. **Counts in headings.** Always show the count in parentheses even when zero. `🔴 Must fix (0)` is a positive signal.
+
+3. **Placeholder strings.** Use `_(none)_` (italic "none") for empty lists. Do not omit the section, do not use `N/A` or dashes.
+
+4. **Verdict rationale length.** One line. If the rationale would exceed one line, choose the single worst finding and name it. The rest is in the Findings section already.
+
+5. **Do not editorialize.** The Verdict block's rationale is factual ("3 done tasks without `verifies` edges") not hortative ("please review carefully").
+
+6. **Do not attach logs.** The report references exported files by path; it does not inline the full event stream. Large inlined blobs defeat the "pasteable" goal.
+
+7. **Language.** English in the template, matching the rest of the skill. The user-facing rendered report can inherit English safely — the findings themselves contain `node_id` values, which are codepoints, not prose.
+
+8. **Section order is fixed.** Verdict → Health → Findings → Manual cross-check → Recommended next steps → Snapshot references. Do not reorder per case.
+
+---
+
+## Recording the report (opt-in)
+
+Only when the user explicitly asks ("record this review", "evidence として残して", etc.):
+
+```sh
+cg evidence add --case <case_id> \
+  --id "evidence_review_$(date -u +%Y%m%dT%H%M%SZ)" \
+  --title "Review report at revision <n>" \
+  --target "<case_root_or_goal_id>" \
+  --description "$(cat <path-to-rendered-report>)"
+```
+
+Choose `<case_root_or_goal_id>` in this priority:
+1. A single `kind:goal` node if the case has exactly one goal.
+2. The most recently updated `kind:goal` node if the case has multiple.
+3. The `case_id` itself as the target — only when no goal exists (which is unusual; most cases have at least one).
+
+Never attach the review to an individual task; the review's scope is the whole case.
+
+Record **only once per human-requested recording action**. If the user calls the skill again and says "record" a second time, create a new evidence node with a fresh timestamp rather than overwriting — historical reviews are independently useful.

--- a/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
@@ -73,7 +73,7 @@ cg blockers --case <id> --format json
 - 🟡 `frontier-nonempty-at-review`: case is `open` with `frontier` ≠ ∅ and the user prompted for a completion review.
 - 🟡 `blockers-active-at-review`: unresolved blockers exist at review time.
 
-**Hard stop.** If `cg events verify` fails, do not run Phases C–F. Render the report with Verdict = 🔴 Red + Summary = "event log integrity failure — graph not trustworthy".
+**Hard stop.** If `cg events verify` fails, do not run Phases C–F. Render the report with Verdict = ⛔ REVIEW ABORTED + Summary = "event log integrity failure — graph not trustworthy".
 
 ---
 
@@ -103,18 +103,26 @@ jq '
   | map(.node_id)
 ' /tmp/cg-review-view.json
 
-# Empty or placeholder evidence — the placeholder regex matches
-# evidence-integrity-rules.md Rule 2 verbatim.
+# Empty or placeholder evidence — mirrors evidence-integrity-rules.md Rule 2.
+# Suspicious when any of: length<20 | trimmed placeholder | trimmed empty | trimmed punct-only.
 jq '
   .data.nodes
   | map(select(.kind == "evidence"))
-  | map({
-      node_id,
-      description_len: (.description // "" | length),
-      title,
-      suspicious: ((.description // "" | length) < 20
-                   or (.description // "" | test("^(実施|完了|done|ok|yes|finished)[.。]?$"; "i")))
-    })
+  | map(
+      . as $n
+      | ((.description // "") | gsub("^\\s+|\\s+$"; "")) as $trimmed
+      | {
+          node_id,
+          description_len: (($n.description // "") | length),
+          title,
+          suspicious: (
+            (($n.description // "") | length) < 20
+            or ($trimmed == "")
+            or ($trimmed | test("^(実施|完了|done|ok|yes|finished)[.。]?$"; "i"))
+            or ($trimmed | test("^[\\p{P}\\p{S}]+$"; "u"))
+          )
+        }
+    )
   | map(select(.suspicious))
 ' /tmp/cg-review-view.json
 ```

--- a/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
@@ -86,9 +86,15 @@ Full rules live in [evidence-integrity-rules.md](evidence-integrity-rules.md). T
 **Commands.**
 
 ```sh
-# Done task/decision without any incoming verifies edge
+# Done task/decision without any incoming verifies edge from an evidence node.
+# A `verifies` edge whose source is not kind=="evidence" is itself a Rule 5 violation and
+# must not be counted as verification here.
 jq '
-  ([.data.edges[] | select(.type == "verifies") | .target_id]) as $verified
+  ([.data.nodes[] | select(.kind == "evidence") | .node_id]) as $evidenceIds
+  | ([.data.edges[]
+      | select(.type == "verifies")
+      | select(.source_id as $s | $evidenceIds | index($s))
+      | .target_id]) as $verified
   | .data.nodes
   | map(select(.kind == "task" or .kind == "decision"))
   | map(select(.state == "done"))
@@ -96,7 +102,8 @@ jq '
   | map(.node_id)
 ' /tmp/cg-review-view.json
 
-# Empty or placeholder evidence
+# Empty or placeholder evidence — the placeholder regex matches
+# evidence-integrity-rules.md Rule 2 verbatim.
 jq '
   .data.nodes
   | map(select(.kind == "evidence"))
@@ -105,7 +112,7 @@ jq '
       description_len: (.description // "" | length),
       title,
       suspicious: ((.description // "" | length) < 20
-                   or (.description // "" | test("^(実施|完了|done|ok)$"; "i")))
+                   or (.description // "" | test("^(実施|完了|done|ok|yes|finished)[.。]?$"; "i")))
     })
   | map(select(.suspicious))
 ' /tmp/cg-review-view.json

--- a/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
@@ -233,7 +233,7 @@ jq '
 **What to enumerate.**
 
 - **Files**: values in `metadata.file`, or paths matched by regex in description. Render as `- git log -- <path>  # verify touched` in the report.
-- **PRs / issues**: `metadata.pr_url`, or `#N` / `github.com` strings in description. Render as `- gh pr view <n> / gh issue view <n>  # confirm exists`.
+- **PRs / issues**: `metadata.pr_url`, or `#N` / GitHub URL strings in description. Render as `- gh pr view <n> / gh issue view <n>  # confirm exists`.
 - **Commits**: `metadata.commit_sha`. Render as `- git show <sha>  # confirm applies`.
 - **Tests**: `metadata.test` or description substrings like `pnpm test <name>`. Render as `- pnpm test <name>  # rerun`.
 - **URLs**: anything else. Render as a clickable link with no auto-action.

--- a/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
@@ -6,10 +6,12 @@ All commands are read-only. Never emit `cg node ...`, `cg edge ...`, `cg task ..
 
 Inputs the skill accepts:
 - `--case <id>` (required)
-- `--since-revision <n>` (optional) — clip Phase E to events with `revision > n`
-- `--since-timestamp <ISO8601>` (optional) — clip Phase E to events with `created_at >= <ts>`
+- `--since-revision <n>` (optional) — clip Phase E to events with `revision_hint > n`
+- `--since-timestamp <ISO8601>` (optional) — clip Phase E to events with `timestamp >= <ts>`
 
 Output shape is fixed by [report-template.md](report-template.md). Findings accumulate across phases and get rendered in one place at the end.
+
+All CLI results use the shape `{ ok, command, data, revision? }`, so every jq expression below unwraps with `.data...`.
 
 ---
 
@@ -17,23 +19,26 @@ Output shape is fixed by [report-template.md](report-template.md). Findings accu
 
 **Goal.** Know what you are reviewing before judging anything.
 
-**Commands.**
+**Commands.** Use `cg case view` (not `cg case show`) because only `view` exposes the full `nodes[]` / `edges[]` / `derived[]` / `validation[]` arrays used by later phases.
 
 ```sh
-cg case show --case <id> --format json > /tmp/cg-review-snapshot.json
-cat /tmp/cg-review-snapshot.json | jq '.data.revision.current, .data.caseRecord.state'
-cat /tmp/cg-review-snapshot.json | jq '
-  .data.nodes | [to_entries[].value]
-  | group_by(.kind) | map({kind: .[0].kind, total: length,
-      by_state: (group_by(.state) | map({state: .[0].state, n: length}))})
-'
+cg case show --case <id> --format json > /tmp/cg-review-show.json
+cg case view --case <id> --format json > /tmp/cg-review-view.json
+
+jq '.data.revision.current, .data.case.state' /tmp/cg-review-show.json
+jq '
+  .data.nodes
+  | group_by(.kind)
+  | map({ kind: .[0].kind, total: length,
+          by_state: (group_by(.state) | map({ state: .[0].state, n: length })) })
+' /tmp/cg-review-view.json
 ```
 
 **What to look for.**
 
 - Revision range covered by the review. If `--since-revision` was passed, the range is `[since+1, current]`; otherwise `[1, current]`.
 - Composition of the case: how many `goal`, `task`, `decision`, `event`, `evidence` nodes, and their state distribution.
-- Whether `caseRecord.state` is `open` or `closed`. A closed case under review means someone already pulled the trigger on `cg case close`; findings about missing evidence are more severe.
+- Whether the case is `open` or `closed` (from `cg case show`'s `data.case.state`). A closed case under review means someone already pulled the trigger on `cg case close`; findings about missing evidence are more severe.
 
 **Findings.**
 
@@ -56,19 +61,19 @@ cg blockers --case <id> --format json
 
 **What to look for.**
 
-- `validate` returns `errors` and `warnings` counts. Errors > 0 → 🔴.
-- `events verify` confirms each event envelope is well-formed and replayable. Failure → **HARD STOP**.
+- `cg validate` returns graph-level `errors` and `warnings` counts. Errors > 0 → 🔴.
+- `cg events verify` replays the event log (via `replayCaseEvents`). A structural failure (unknown event type, missing `case.created`, patch replay mismatch) throws and the command exits non-zero → **HARD STOP**. Graph-level validation is *not* surfaced here — rely on `cg validate` above for that.
 - `frontier` is empty if the case really is done. Non-empty frontier on a case the user claims is "finished" → 🟡.
 - `blockers` lists active `depends_on` / `waits_for` / `state` / `cycle` reasons. Active blockers in a claimed-done case → 🟡 (or 🔴 if combined with a done-without-verifies finding in Phase C).
 
 **Findings.**
 
-- 🔴 `validation-error`: validation returned errors. Emit one finding per error with the node id and message.
-- 🔴 `event-log-integrity-failure`: events verify failed. Report the first failing event and stop — the rest of the review is unreliable and must be surfaced as "REVIEW ABORTED" in the Verdict block.
+- 🔴 `validation-error`: `cg validate` returned errors. Emit one finding per error with the node id and message.
+- 🔴 `event-log-integrity-failure`: `cg events verify` exited non-zero. Report the exit output and stop — the rest of the review is unreliable and must be surfaced as "REVIEW ABORTED" in the Verdict block.
 - 🟡 `frontier-nonempty-at-review`: case is `open` with `frontier` ≠ ∅ and the user prompted for a completion review.
 - 🟡 `blockers-active-at-review`: unresolved blockers exist at review time.
 
-**Hard stop.** If events verify fails, do not run Phases C–F. Render the report with Verdict = 🔴 Red + Summary = "event log integrity failure — graph not trustworthy".
+**Hard stop.** If `cg events verify` fails, do not run Phases C–F. Render the report with Verdict = 🔴 Red + Summary = "event log integrity failure — graph not trustworthy".
 
 ---
 
@@ -76,25 +81,24 @@ cg blockers --case <id> --format json
 
 **Goal.** Check that every self-declared completion is backed by a `verifies` edge from an `evidence` node, and that the evidence itself is not a token.
 
-Full rules live in [evidence-integrity-rules.md](evidence-integrity-rules.md). This phase applies them against the snapshot.
+Full rules live in [evidence-integrity-rules.md](evidence-integrity-rules.md). This phase applies them against the view snapshot (`/tmp/cg-review-view.json`).
 
 **Commands.**
 
 ```sh
 # Done task/decision without any incoming verifies edge
-cat /tmp/cg-review-snapshot.json | jq '
-  .data.nodes as $n
-  | [.data.edges | to_entries[] | .value | select(.type=="verifies") | .target_id] as $verified
-  | $n | [to_entries[].value]
+jq '
+  ([.data.edges[] | select(.type == "verifies") | .target_id]) as $verified
+  | .data.nodes
   | map(select(.kind == "task" or .kind == "decision"))
   | map(select(.state == "done"))
   | map(select(.node_id as $id | $verified | index($id) | not))
   | map(.node_id)
-'
+' /tmp/cg-review-view.json
 
 # Empty or placeholder evidence
-cat /tmp/cg-review-snapshot.json | jq '
-  .data.nodes | [to_entries[].value]
+jq '
+  .data.nodes
   | map(select(.kind == "evidence"))
   | map({
       node_id,
@@ -104,10 +108,10 @@ cat /tmp/cg-review-snapshot.json | jq '
                    or (.description // "" | test("^(実施|完了|done|ok)$"; "i")))
     })
   | map(select(.suspicious))
-'
+' /tmp/cg-review-view.json
 ```
 
-For just-in-time detection, cross-reference the event log (see Phase E's jq cookbook for the full pattern). Per rule, flag evidence whose `evidence.attached` event's `created_at` is within 2 seconds of the verified node's `node.state_changed` → `done` event.
+For just-in-time detection, cross-reference the event log (see Phase E's jq cookbook for the full pattern). Per rule, flag evidence whose `evidence.attached` event's `timestamp` is within 2 seconds of the verified node's `node.state_changed` → `done` event.
 
 **Findings.**
 
@@ -124,35 +128,35 @@ For just-in-time detection, cross-reference the event log (see Phase E's jq cook
 **Commands.**
 
 ```sh
-cat /tmp/cg-review-snapshot.json | jq '
-  .data.nodes | [to_entries[].value]
+jq '
+  .data.nodes
   | map(select(.kind == "decision"))
   | map({
       node_id, title, state,
-      result: (.metadata.result // null),
+      result: (.metadata.decision_result // .metadata.result // null),
       has_desc: (((.description // "") | length) > 0)
     })
   | map(select(.state == "done"))
   | map(select(.result == null and (.has_desc | not)))
-'
+' /tmp/cg-review-view.json
 
 # Alternative-to edges captured
-cat /tmp/cg-review-snapshot.json | jq '
-  .data.edges | [to_entries[] | .value]
+jq '
+  .data.edges
   | map(select(.type == "alternative_to"))
   | group_by(.source_id)
   | map({decision: .[0].source_id, alternatives: map(.target_id)})
-'
+' /tmp/cg-review-view.json
 ```
 
 **What to look for.**
 
-- A done decision with neither `metadata.result` nor description is a **naked decision**: the choice is recorded but the reasoning is lost.
+- A done decision with neither `metadata.decision_result` nor description is a **naked decision**: the choice is recorded but the reasoning is lost. (`decision_result` is what `cg decision decide --result <text>` writes; older graphs may have `metadata.result`.)
 - Presence of `alternative_to` edges is a bonus signal that the agent considered alternatives. Missing alternatives is a 🟢 note only (common; not a finding on its own).
 
 **Findings.**
 
-- 🟡 `naked-decision`: decision done without `metadata.result` and with empty description.
+- 🟡 `naked-decision`: decision done without a decision result in metadata and with empty description.
 - 🟢 `decision-without-alternatives` (informational only, not a blocker).
 
 ---
@@ -161,7 +165,7 @@ cat /tmp/cg-review-snapshot.json | jq '
 
 **Goal.** Classify `patch.applied` events by actor, detect orphan workers, and list state transitions the agent may have quietly abandoned.
 
-Detailed jq patterns in [event-trail-jq.md](event-trail-jq.md).
+Detailed jq patterns — including the exact payload paths, since payload shapes vary per event type — live in [event-trail-jq.md](event-trail-jq.md).
 
 **Commands (pre-clip for `--since-revision` / `--since-timestamp` if set).**
 
@@ -171,10 +175,10 @@ cg events export --case <id> --format json > /tmp/cg-review-events.json
 
 Then apply the cookbook jq patterns to produce:
 
-1. **Patch applications by actor** — count of `patch.applied` events grouped by `payload.generator.kind` (`human` / `agent` / `worker` / `importer` / `sync` / `planner`).
-2. **AI patches without evidence** — AI-authored `patch.applied` events (`generator.kind in {agent, worker}`) that do not have an `evidence.attached` event in the same revision range. Flag as 🟡.
-3. **Orphan workers** — `worker.dispatched` events without a subsequent `worker.finished` for the same worker + target. Flag as 🔴.
-4. **Failure history** — `node.state_changed` events that transitioned to `cancelled` or `failed`. List title, node id, reason, and whether the failure was later reversed. These are 🟢 notes unless a `failed` is immediately followed by a `done` on the same node without evidence — then 🟡.
+1. **Patch applications by actor** — count of `patch.applied` events grouped by `payload.patch.generator.kind` (`human` / `agent` / `worker` / `importer` / `sync` / `planner`).
+2. **AI patches without evidence** — AI-authored `patch.applied` events (`generator.kind in {agent, worker}`) with no `evidence.attached` whose `verifies_edge.target_id` is in the patch's affected node set, within the clip window. Flag as 🟡.
+3. **Orphan workers** — `worker.dispatched` events without a subsequent `worker.finished` with the same `command_id`. Flag as 🔴.
+4. **Failure history** — `node.state_changed` events that transitioned to `cancelled` or `failed` (via `payload.state`). List title, node id, reason, and whether the failure was later reversed. These are 🟢 notes unless a `failed` is immediately followed by a `done` on the same node without evidence — then 🟡.
 5. **Worker timing outliers (optional)** — worker runs whose `dispatched`→`finished` delta is > 10 minutes. 🟢 note.
 
 **Findings.**
@@ -193,8 +197,8 @@ Then apply the cookbook jq patterns to produce:
 **Commands.**
 
 ```sh
-cat /tmp/cg-review-snapshot.json | jq '
-  .data.nodes | [to_entries[].value]
+jq '
+  .data.nodes
   | map(select(.kind == "evidence"))
   | map({
       evidence_id: .node_id,
@@ -207,7 +211,7 @@ cat /tmp/cg-review-snapshot.json | jq '
       test: .metadata.test
     })
   | map(select(.file or .url or .pr or .commit or .test or ((.description // "") | test("https?://|#[0-9]+|\\bpackages/|\\btests/"))))
-'
+' /tmp/cg-review-view.json
 ```
 
 **What to enumerate.**

--- a/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
@@ -86,14 +86,15 @@ Full rules live in [evidence-integrity-rules.md](evidence-integrity-rules.md). T
 **Commands.**
 
 ```sh
-# Done task/decision without any incoming verifies edge from an evidence node.
-# A `verifies` edge whose source is not kind=="evidence" is itself a Rule 5 violation and
-# must not be counted as verification here.
+# Done task/decision without any incoming verifies edge from a *done* evidence node.
+# Matches `validation.ts::hasEvidenceForNode` — an in-progress/failed evidence node does
+# not count. A `verifies` edge whose source is not kind=="evidence" is itself a Rule 5
+# violation and must not be counted as verification here either.
 jq '
-  ([.data.nodes[] | select(.kind == "evidence") | .node_id]) as $evidenceIds
+  ([.data.nodes[] | select(.kind == "evidence" and .state == "done") | .node_id]) as $doneEvidenceIds
   | ([.data.edges[]
       | select(.type == "verifies")
-      | select(.source_id as $s | $evidenceIds | index($s))
+      | select(.source_id as $s | $doneEvidenceIds | index($s))
       | .target_id]) as $verified
   | .data.nodes
   | map(select(.kind == "task" or .kind == "decision"))

--- a/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
@@ -1,0 +1,236 @@
+# Review phases
+
+Six ordered phases. Each has a goal, concrete commands, what to look for, finding classification, and (for Phase B) a hard-stop condition.
+
+All commands are read-only. Never emit `cg node ...`, `cg edge ...`, `cg task ...`, `cg patch apply`, or any other mutating verb from inside these phases. The one exception — `cg evidence add` to record the review — lives outside the phases and runs only on explicit user request.
+
+Inputs the skill accepts:
+- `--case <id>` (required)
+- `--since-revision <n>` (optional) — clip Phase E to events with `revision > n`
+- `--since-timestamp <ISO8601>` (optional) — clip Phase E to events with `created_at >= <ts>`
+
+Output shape is fixed by [report-template.md](report-template.md). Findings accumulate across phases and get rendered in one place at the end.
+
+---
+
+## Phase A — Orientation
+
+**Goal.** Know what you are reviewing before judging anything.
+
+**Commands.**
+
+```sh
+cg case show --case <id> --format json > /tmp/cg-review-snapshot.json
+cat /tmp/cg-review-snapshot.json | jq '.data.revision.current, .data.caseRecord.state'
+cat /tmp/cg-review-snapshot.json | jq '
+  .data.nodes | [to_entries[].value]
+  | group_by(.kind) | map({kind: .[0].kind, total: length,
+      by_state: (group_by(.state) | map({state: .[0].state, n: length}))})
+'
+```
+
+**What to look for.**
+
+- Revision range covered by the review. If `--since-revision` was passed, the range is `[since+1, current]`; otherwise `[1, current]`.
+- Composition of the case: how many `goal`, `task`, `decision`, `event`, `evidence` nodes, and their state distribution.
+- Whether `caseRecord.state` is `open` or `closed`. A closed case under review means someone already pulled the trigger on `cg case close`; findings about missing evidence are more severe.
+
+**Findings.**
+
+- No findings emitted directly. This phase just populates the Health block in the report.
+
+---
+
+## Phase B — State Health
+
+**Goal.** Prove the graph is internally consistent before trusting anything later.
+
+**Commands (in order).**
+
+```sh
+cg validate --case <id> --format json
+cg events verify --case <id> --format json
+cg frontier --case <id> --format json
+cg blockers --case <id> --format json
+```
+
+**What to look for.**
+
+- `validate` returns `errors` and `warnings` counts. Errors > 0 → 🔴.
+- `events verify` confirms each event envelope is well-formed and replayable. Failure → **HARD STOP**.
+- `frontier` is empty if the case really is done. Non-empty frontier on a case the user claims is "finished" → 🟡.
+- `blockers` lists active `depends_on` / `waits_for` / `state` / `cycle` reasons. Active blockers in a claimed-done case → 🟡 (or 🔴 if combined with a done-without-verifies finding in Phase C).
+
+**Findings.**
+
+- 🔴 `validation-error`: validation returned errors. Emit one finding per error with the node id and message.
+- 🔴 `event-log-integrity-failure`: events verify failed. Report the first failing event and stop — the rest of the review is unreliable and must be surfaced as "REVIEW ABORTED" in the Verdict block.
+- 🟡 `frontier-nonempty-at-review`: case is `open` with `frontier` ≠ ∅ and the user prompted for a completion review.
+- 🟡 `blockers-active-at-review`: unresolved blockers exist at review time.
+
+**Hard stop.** If events verify fails, do not run Phases C–F. Render the report with Verdict = 🔴 Red + Summary = "event log integrity failure — graph not trustworthy".
+
+---
+
+## Phase C — Evidence Integrity
+
+**Goal.** Check that every self-declared completion is backed by a `verifies` edge from an `evidence` node, and that the evidence itself is not a token.
+
+Full rules live in [evidence-integrity-rules.md](evidence-integrity-rules.md). This phase applies them against the snapshot.
+
+**Commands.**
+
+```sh
+# Done task/decision without any incoming verifies edge
+cat /tmp/cg-review-snapshot.json | jq '
+  .data.nodes as $n
+  | [.data.edges | to_entries[] | .value | select(.type=="verifies") | .target_id] as $verified
+  | $n | [to_entries[].value]
+  | map(select(.kind == "task" or .kind == "decision"))
+  | map(select(.state == "done"))
+  | map(select(.node_id as $id | $verified | index($id) | not))
+  | map(.node_id)
+'
+
+# Empty or placeholder evidence
+cat /tmp/cg-review-snapshot.json | jq '
+  .data.nodes | [to_entries[].value]
+  | map(select(.kind == "evidence"))
+  | map({
+      node_id,
+      description_len: (.description // "" | length),
+      title,
+      suspicious: ((.description // "" | length) < 20
+                   or (.description // "" | test("^(実施|完了|done|ok)$"; "i")))
+    })
+  | map(select(.suspicious))
+'
+```
+
+For just-in-time detection, cross-reference the event log (see Phase E's jq cookbook for the full pattern). Per rule, flag evidence whose `evidence.attached` event's `created_at` is within 2 seconds of the verified node's `node.state_changed` → `done` event.
+
+**Findings.**
+
+- 🔴 `done-without-verifies`: a `task` or `decision` node is `done` but no `verifies` edge points at it. Name every such node.
+- 🟡 `empty-evidence`: evidence description is <20 chars or matches a placeholder pattern.
+- 🟡 `just-in-time-evidence`: evidence attached in the same second (or within 2s) as the target's state change to done. Demote to 🟢 note only when the evidence description references a pre-existing artifact (PR URL, commit hash) whose timestamp predates the evidence — see [evidence-integrity-rules.md](evidence-integrity-rules.md) for the acceptable-exception rule.
+
+---
+
+## Phase D — Decision Traceability
+
+**Goal.** Every completed `decision` should explain itself.
+
+**Commands.**
+
+```sh
+cat /tmp/cg-review-snapshot.json | jq '
+  .data.nodes | [to_entries[].value]
+  | map(select(.kind == "decision"))
+  | map({
+      node_id, title, state,
+      result: (.metadata.result // null),
+      has_desc: (((.description // "") | length) > 0)
+    })
+  | map(select(.state == "done"))
+  | map(select(.result == null and (.has_desc | not)))
+'
+
+# Alternative-to edges captured
+cat /tmp/cg-review-snapshot.json | jq '
+  .data.edges | [to_entries[] | .value]
+  | map(select(.type == "alternative_to"))
+  | group_by(.source_id)
+  | map({decision: .[0].source_id, alternatives: map(.target_id)})
+'
+```
+
+**What to look for.**
+
+- A done decision with neither `metadata.result` nor description is a **naked decision**: the choice is recorded but the reasoning is lost.
+- Presence of `alternative_to` edges is a bonus signal that the agent considered alternatives. Missing alternatives is a 🟢 note only (common; not a finding on its own).
+
+**Findings.**
+
+- 🟡 `naked-decision`: decision done without `metadata.result` and with empty description.
+- 🟢 `decision-without-alternatives` (informational only, not a blocker).
+
+---
+
+## Phase E — Event Trail Audit
+
+**Goal.** Classify `patch.applied` events by actor, detect orphan workers, and list state transitions the agent may have quietly abandoned.
+
+Detailed jq patterns in [event-trail-jq.md](event-trail-jq.md).
+
+**Commands (pre-clip for `--since-revision` / `--since-timestamp` if set).**
+
+```sh
+cg events export --case <id> --format json > /tmp/cg-review-events.json
+```
+
+Then apply the cookbook jq patterns to produce:
+
+1. **Patch applications by actor** — count of `patch.applied` events grouped by `payload.generator.kind` (`human` / `agent` / `worker` / `importer` / `sync` / `planner`).
+2. **AI patches without evidence** — AI-authored `patch.applied` events (`generator.kind in {agent, worker}`) that do not have an `evidence.attached` event in the same revision range. Flag as 🟡.
+3. **Orphan workers** — `worker.dispatched` events without a subsequent `worker.finished` for the same worker + target. Flag as 🔴.
+4. **Failure history** — `node.state_changed` events that transitioned to `cancelled` or `failed`. List title, node id, reason, and whether the failure was later reversed. These are 🟢 notes unless a `failed` is immediately followed by a `done` on the same node without evidence — then 🟡.
+5. **Worker timing outliers (optional)** — worker runs whose `dispatched`→`finished` delta is > 10 minutes. 🟢 note.
+
+**Findings.**
+
+- 🔴 `orphan-worker`: `worker.dispatched` without matching `worker.finished`.
+- 🟡 `ai-patch-without-evidence`: any `patch.applied` with `generator.kind in {agent, worker}` in the review window whose summary claims task progress but has no accompanying `evidence.attached` on a target node in the same revision range.
+- 🟡 `silent-reversal`: a node went `failed` → `done` without a new evidence attachment between the two transitions.
+- 🟢 `actor-distribution` (informational): pie-of-text showing how much of the work was AI-authored.
+
+---
+
+## Phase F — Reality Cross-Check enumeration
+
+**Goal.** Do not verify — enumerate. The skill collects external references from evidence nodes and renders them as a checklist. The human (or a later tool) runs the actual checks.
+
+**Commands.**
+
+```sh
+cat /tmp/cg-review-snapshot.json | jq '
+  .data.nodes | [to_entries[].value]
+  | map(select(.kind == "evidence"))
+  | map({
+      evidence_id: .node_id,
+      title,
+      description,
+      file: .metadata.file,
+      url: .metadata.url,
+      pr: .metadata.pr_url,
+      commit: .metadata.commit_sha,
+      test: .metadata.test
+    })
+  | map(select(.file or .url or .pr or .commit or .test or ((.description // "") | test("https?://|#[0-9]+|\\bpackages/|\\btests/"))))
+'
+```
+
+**What to enumerate.**
+
+- **Files**: values in `metadata.file`, or paths matched by regex in description. Render as `- git log -- <path>  # verify touched` in the report.
+- **PRs / issues**: `metadata.pr_url`, or `#N` / `github.com` strings in description. Render as `- gh pr view <n> / gh issue view <n>  # confirm exists`.
+- **Commits**: `metadata.commit_sha`. Render as `- git show <sha>  # confirm applies`.
+- **Tests**: `metadata.test` or description substrings like `pnpm test <name>`. Render as `- pnpm test <name>  # rerun`.
+- **URLs**: anything else. Render as a clickable link with no auto-action.
+
+**Findings.**
+
+- Always emitted as a dedicated "Manual cross-check required" section, not as 🔴/🟡/🟢 findings. The number of items gates the Verdict: a Green graph with 0 Phase F items is fully approved; with >0 items, the skill says "Green graph, N external checks pending — human owns final approval".
+
+---
+
+## Phase ordering rationale (why this order)
+
+1. **A before B**: you need the snapshot before you can validate against it.
+2. **B hard-stops before C–F**: no point auditing an unverified event log.
+3. **C before D**: evidence integrity is a stronger failure mode than decision narrative thinness.
+4. **D before E**: decision findings may be explained by patch events; read them in the right direction.
+5. **E before F**: Phase E tells you *which* AI patches produced which evidence; Phase F then asks whether those evidence claims are real.
+6. **F last**: nothing else depends on the human cross-check result; it can be deferred.
+
+Do not rearrange. Phase B must be able to abort the pipeline before any later phase runs.

--- a/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
+++ b/casegraph-plugin/skills/cg-review-driver/references/review-phases.md
@@ -231,7 +231,7 @@ jq '
 
 **Findings.**
 
-- Always emitted as a dedicated "Manual cross-check required" section, not as 🔴/🟡/🟢 findings. The number of items gates the Verdict: a Green graph with 0 Phase F items is fully approved; with >0 items, the skill says "Green graph, N external checks pending — human owns final approval".
+- Always emitted as a dedicated "Manual cross-check required" section, not as 🔴/🟡/🟢 findings. Final approval remains human-owned in every case — a Green graph means the graph side passes, not that the PR is approved. With >0 items, the skill says "Green graph, N external checks pending — human owns final approval"; with 0 items, the skill says "Green graph, no external checks pending — final approval remains human-owned".
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a new skill `cg-review-driver` to `casegraph-plugin` for auditing AI-performed work on a CaseGraph case. Parallels `cg-workflow-driver` (write side) as its read-only review counterpart. Bumps plugin to **0.1.6**.

### Why

After an AI-driven loop marks tasks done, there is currently no structured way to verify the work other than ad-hoc scanning of evidence nodes, events, and PR diffs. This skill codifies the review into a reproducible six-phase loop with machine-checked rules and a fixed report shape. A Green verdict does not mean auto-approve — it means the graph side passes; the human still owns the Phase F external cross-checks.

### Design

Six ordered phases:

1. **Orientation** — snapshot case state, count nodes by kind × state.
2. **State Health** — `cg validate` + `cg events verify` (hard-stop on integrity failure), `cg frontier`, `cg blockers`.
3. **Evidence Integrity** — done-without-verifies (🔴), empty-evidence (🟡), just-in-time evidence (🟡 with timing delta).
4. **Decision Traceability** — naked-decision (🟡) = done decision with no `metadata.result` and empty description.
5. **Event Trail Audit** — AI-authored `patch.applied` without accompanying evidence (🟡), orphan workers (🔴), silent reversals (`failed` → `done` without intervening evidence, 🟡).
6. **Reality Cross-Check** — enumerate files/PRs/commits/tests/URLs from evidence metadata; emit as a "Manual cross-check required" section. Skill does not auto-verify.

Verdict gates:
- 🔴 Red: event log verify failed OR validation errors OR done-without-verifies OR orphan worker.
- 🟡 Yellow: just-in-time evidence OR naked decision OR AI patch without evidence OR open case with non-empty frontier when prompt implied completion.
- 🟢 Green: only notes and "Manual cross-check required" items remain.
- ⛔ REVIEW ABORTED: Phase B integrity failure causes pipeline abort; Phases C–F do not run.

### Opt-ins

- `--since-revision <n>` / `--since-timestamp <ISO>` — scope the review to a revision window (avoids re-reviewing long-running cases end to end).
- `--record-as-evidence` — attach the review report as an `evidence` node on the case root via a single `cg evidence add` call. Default off; this is the only mutating command the skill can emit.

### Files

- `casegraph-plugin/skills/cg-review-driver/SKILL.md` (~110 lines) — frontmatter, operating loop, verdict gates, NOT-do list, references.
- `casegraph-plugin/skills/cg-review-driver/references/review-phases.md` — detailed phase procedures.
- `casegraph-plugin/skills/cg-review-driver/references/evidence-integrity-rules.md` — formal rules for done-without-verifies, empty-evidence, just-in-time evidence, silent-reversal, verifies-edge schema sanity. Includes downgrade paths when rules have acceptable exceptions.
- `casegraph-plugin/skills/cg-review-driver/references/event-trail-jq.md` — jq cookbook for Phase E (7 patterns).
- `casegraph-plugin/skills/cg-review-driver/references/report-template.md` — verbatim markdown output shape with rendering rules.
- `casegraph-plugin/.claude-plugin/plugin.json` — 0.1.5 → 0.1.6.
- `.claude-plugin/marketplace.json` — 0.1.5 → 0.1.6.

### Non-goals

- Not a patch author. Fixes suggested by review → `casegraph-patch`.
- Not a closer. `cg case close` stays with `cg-workflow-driver`.
- Not a reality cross-checker. Phase F lists items; the human runs `git log`, reruns tests, opens PRs.
- Not a batch reviewer across multiple cases (deferred to v0.2).

### Validation

`plugin-dev:plugin-validator` confirmed the skill structure: valid JSON, frontmatter correct, all 4 reference links resolve, no stray mutating `cg` commands outside the explicit opt-in block.

## Test plan

- [ ] Install plugin at 0.1.6 via `/plugin marketplace add CAPHTECH/casegraph` + `/plugin install casegraph-plugin@casegraph-marketplace` (after PRs #3 and #4 land) and confirm the new skill loads.
- [ ] Invoke the skill on a completed case with mixed AI and human evidence; verify the report renders all sections including 🟢 notes for notes and _(none)_ for empty findings.
- [ ] Force a test case: attach evidence in the same second as a state-change event; confirm 🟡 `just-in-time-evidence` fires.
- [ ] Force another: mark a task done with no `verifies` edge; confirm 🔴 `done-without-verifies`.
- [ ] Pass `--since-revision <n>` and confirm Phase E is scoped.
- [ ] Ask "record this review" and confirm a single `cg evidence add` is emitted with a sensible target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Version Updates**
  * プラグインのバージョンを 0.1.5 から 0.1.6 に更新

* **Documentation**
  * cg-review-driver スキル用の包括的ドキュメントと参照資料を追加（6段階の読取専用レビュー手順、状態健全性ハードストップ、エビデンス整合性ルール、イベント解析の jq カタログ、固定形式のレポートテンプレート、範囲指定と記録モード、運用上の注意事項）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->