### PR TITLE
feat(cli): wire --version/-V to the cg command

### DIFF
--- a/packages/cli/src/app.ts
+++ b/packages/cli/src/app.ts
@@ -1,4 +1,6 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   addEdge,
   addEvidence,
@@ -66,6 +68,10 @@ import {
 import { runSinkPull, runSinkPush } from "./sink-host.js";
 import { runWorkerExecute, type WorkerRunResult } from "./worker-host.js";
 
+const cliPackage = JSON.parse(
+  readFileSync(fileURLToPath(new URL("../package.json", import.meta.url)), "utf8")
+) as { version: string };
+
 interface WorkerRunCommandOptions {
   worker: string;
   case: string;
@@ -85,6 +91,7 @@ export async function runCli(
   program
     .name("cg")
     .description("CaseGraph CLI")
+    .version(cliPackage.version, "-V, --version", "Show CaseGraph CLI version")
     .option("--workspace <path>")
     .option("--format <format>", "text or json", "text")
     .option("--quiet")

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -34,6 +34,28 @@ describe("cli phase 1 acceptance", () => {
     expect(stderr.join("")).not.toContain("internal_error");
   });
 
+  it("prints the CLI package version for --version and -V", async () => {
+    const packageJson = JSON.parse(
+      await readFile(path.resolve(import.meta.dirname, "../packages/cli/package.json"), "utf8")
+    ) as { version: string };
+
+    for (const flag of ["--version", "-V"]) {
+      const stdout: string[] = [];
+      const stderr: string[] = [];
+
+      const code = await runCli([flag], {
+        io: {
+          stdout: (text) => stdout.push(text),
+          stderr: (text) => stderr.push(text)
+        }
+      });
+
+      expect(code).toBe(0);
+      expect(stdout.join("").trim()).toBe(packageJson.version);
+      expect(stderr.join("")).toBe("");
+    }
+  });
+
   it("creates a release case and exposes frontier/blockers in JSON", async () => {
     const workspaceRoot = await createTempWorkspace("casegraph-cli-");
     createdWorkspaces.push(workspaceRoot);


### PR DESCRIPTION
## Summary
- Register `program.version(...)` on the commander root so `cg --version` / `cg -V` print the CLI package version and exit 0. Previously the flag was unregistered even though `isCommanderDisplayExit` (app.ts) already whitelisted `commander.version` as a non-fatal exit code, so this is a pure wiring fix.
- Read the version from `packages/cli/package.json` via `import.meta.url`, so both the vitest-aliased TypeScript source and the published `dist/` entry resolve the same file without relying on bundler JSON import syntax.
- Add a cli.test.ts case asserting both `--version` and `-V` emit the package version on stdout, exit 0, and write nothing to stderr.

## Test plan
- [x] `pnpm build`
- [x] `pnpm exec vitest run tests/cli.test.ts -t "version"`
- [x] `node packages/cli/dist/index.js --version` → `0.1.3`
- [x] `node packages/cli/dist/index.js -V` → `0.1.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * CLIでバージョン情報を表示できるようになりました。`--version` または `-V` フラグでバージョン番号を確認できます。

* **テスト**
  * バージョンフラグの動作を検証する受け入れテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->